### PR TITLE
Prevent invalid page offsets from being calculated for gap entries in DWG reader

### DIFF
--- a/src/io/dwg/dwg_reader.rs
+++ b/src/io/dwg/dwg_reader.rs
@@ -683,7 +683,11 @@ impl<R: Read + Seek> DwgReader<R> {
             if page_number > 0 && page_size > 0 {
                 info.page_records.insert(page_number, (file_offset, page_size as i64));
             }
-            file_offset += page_size as i64;
+            // Only advance for positive sizes; negative/zero sizes in gap entries are
+            // invalid and must not corrupt subsequent page offsets.
+            if page_size > 0 {
+                file_offset += page_size as i64;
+            }
         }
 
         self.notifications.notify(


### PR DESCRIPTION
**Problem**

Some DWG files written by AutoCAD contain gap/free page entries in the AC18 section page map with page_size = 0 or page_size < 0 (e.g. -2). The reader was unconditionally accumulating these into the running file_offset, causing every subsequent page record to be stored at a wrong offset. This manifested as two errors depending on the file:

Invalid file format: Invalid AC18 section map compressed size: <large number> — the section map page was found at a shifted offset, so its header bytes were read as garbage

IO error: failed to fill whole buffer — a bad offset caused a read past end of file

**Root cause**

In read_page_map_ac18, the line:

```
file_offset += page_size as i64;
```

ran unconditionally. A gap entry with `page_size = -2` would decrement `file_offset` by 2, shifting all subsequent page offsets by −2 bytes. The section map header, which should start with magic bytes 0x4163003B, was being read 2 bytes early, producing invalid field values.

**Fix**

Guard the accumulation so only positive page sizes advance the offset:

```
if page_size > 0 {
    file_offset += page_size as i64;
}
```

Non-positive sizes in gap/free entries are not valid page sizes and must not shift the running file offset.
