### PR TITLE
feat(viewport): populate custom_scale from paper-to-model ratio

### DIFF
--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -1394,6 +1394,17 @@ impl DwgDocumentBuilder {
                     e.view_direction = data.view_direction;
                     e.view_target = data.view_target;
                     e.view_height = data.view_height;
+                    // Derive the paper-to-model display ratio that
+                    // AutoCAD shows in its viewport-scale selector.
+                    // `custom_scale` is otherwise never populated, so
+                    // downstream code that reads it (instead of
+                    // recomputing `height / view_height`) sees the
+                    // default 1.0 and renders every viewport at 1:1.
+                    e.custom_scale = if data.view_height.abs() > 1e-10 {
+                        data.height / data.view_height
+                    } else {
+                        1.0
+                    };
                     e.lens_length = data.lens_length;
                     e.front_clip_z = data.front_clip_z;
                     e.back_clip_z = data.back_clip_z;

--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -4641,6 +4641,13 @@ impl<'a> SectionReader<'a> {
         vp.snap_base = Vector3::new(snap_base_x.unwrap_or(0.0), snap_base_y.unwrap_or(0.0), 0.0);
         vp.snap_spacing = Vector3::new(snap_spacing_x.unwrap_or(10.0), snap_spacing_y.unwrap_or(10.0), 0.0);
         vp.grid_spacing = Vector3::new(grid_spacing_x.unwrap_or(10.0), grid_spacing_y.unwrap_or(10.0), 0.0);
+        // Mirror what the DWG builder does: populate `custom_scale`
+        // from the paper-to-model ratio so downstream code that reads
+        // `custom_scale` sees the viewport's display scale instead of
+        // the default 1.0.
+        if vp.view_height.abs() > 1e-10 {
+            vp.custom_scale = vp.height / vp.view_height;
+        }
 
         Ok(Some(vp))
     }


### PR DESCRIPTION
## Summary

`Viewport::custom_scale` is declared on the struct (with default `1.0`) but neither the DXF nor the DWG reader ever sets it. Consumers that prefer reading `custom_scale` to recomputing `height / view_height` silently fall back to `1.0` on every file — which is why renderers that key on this field show every viewport at 1:1 regardless of the saved scale.

## Change

Derive `custom_scale = height / view_height` in both readers right after the existing `view_height` assignment. Falls back to the existing default (`1.0`) when `view_height` is missing or zero. No new bytes are read from the stream.

- `src/io/dwg/dwg_document_builder.rs` — VIEWPORT entity branch
- `src/io/dxf/reader/section_reader.rs` — DXF `read_viewport` finalization

## Test plan

- [ ] DWG file with multiple viewports at different scales — verify `vp.custom_scale` reflects the saved per-viewport ratio instead of staying at `1.0`
- [ ] DXF round-trip — confirm `custom_scale` survives read → write → read
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)