### PR TITLE
Restore DXF section reader fixes lost in PR #21 merge

### DIFF
--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -342,15 +342,24 @@ impl<'a> SectionReader<'a> {
         Ok(())
     }
 
-    /// Read a 3D point header variable (three successive code/value pairs: 10/20/30)
+    /// Read a 3D point header variable (up to three successive code/value pairs: 10/20/30).
+    /// Older formats (e.g. AC1009/R12) may only supply X and Y for variables like $EXTMIN/$EXTMAX.
+    /// Non-coordinate pairs (code 9 = next variable name, code 0 = section end, etc.) are pushed
+    /// back so the main header loop can process them normally.
     fn read_header_point3(&mut self, target: &mut Vector3) -> Result<()> {
         for _ in 0..3 {
             if let Some(p) = self.reader.read_pair()? {
-                if let Some(v) = p.as_double() {
-                    let base = p.code % 100;
-                    if base < 10 || base == 10 { target.x = v; }
-                    else if base >= 20 && base < 30 { target.y = v; }
-                    else { target.z = v; }
+                let base = p.code % 100;
+                // Coordinate codes are 10–39 (X=1x, Y=2x, Z=3x); anything else belongs to the next token
+                if base >= 10 && base < 40 {
+                    if let Some(v) = p.as_double() {
+                        if base < 20 { target.x = v; }
+                        else if base < 30 { target.y = v; }
+                        else { target.z = v; }
+                    }
+                } else {
+                    self.reader.push_back(p);
+                    break;
                 }
             }
         }
@@ -569,8 +578,14 @@ impl<'a> SectionReader<'a> {
                         // Insert block entities into the document's flat entity map
                         // and collect their handles for the block record.
                         let mut entity_handles = Vec::with_capacity(block_entities.len());
-                        for entity in block_entities {
-                            let h = entity.common().handle;
+                        for mut entity in block_entities {
+                            let h = if entity.common().handle.is_null() {
+                                let new_h = document.allocate_handle();
+                                entity.as_entity_mut().set_handle(new_h);
+                                new_h
+                            } else {
+                                entity.common().handle
+                            };
                             entity_handles.push(h);
                             let idx = document.entities.len();
                             document.entities.push(entity);
@@ -578,6 +593,12 @@ impl<'a> SectionReader<'a> {
                         }
 
                         // Find the BlockRecord and set handles
+                        if document.block_records.get(&block_name).is_none() {
+                            let mut br = BlockRecord::new(block_name.clone());
+                            br.handle = document.allocate_handle();
+                            document.block_records.add_or_replace(br);
+                        }
+
                         if let Some(block_record) = document.block_records.get_mut(&block_name) {
                             block_record.entity_handles = entity_handles;
                             block_record.xref_path = block.xref_path.clone();


### PR DESCRIPTION
Three small fixes to `src/io/dxf/reader/section_reader.rs` were merged into
`main` via PR #20 (`morki/dxf-reading`) on **2026-04-19 / 2026-04-20**:

| Commit | Subject |
| --- | --- |
| `a8f59e2` | Ensure BlockRecords are initialized before setting handles in section reader |
| `151db13` | Handle null entity handles in section reader by allocating new handles |
| `f72bb87` | Improve header variable parsing for 3D points in DXF section reader |

PR #21 (`feat: expose paper dimensions and plot rotation on Layout`,
commit `2eaa7aa`, merged 2026-05-01) was developed on a branch that had not
been rebased onto `main` after PR #20 landed. Because PR #21 also edits
`section_reader.rs`, merging it overwrote the three regions above with their
pre-#20 contents, silently reverting the fixes.

This PR re-applies those three fixes on top of current `main`. PR #21's own
additions (the `paper_width` / `paper_height` / `plot_rotation` parsing block
in the layout reader) are intentionally left untouched.