### PR TITLE
fix(dwg): cap hatch boundary-handle count with safe_count

### DIFF
--- a/src/io/dwg/dwg_stream_readers/object_reader/entities.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/entities.rs
@@ -1280,7 +1280,12 @@ pub fn read_hatch_boundary_path(reader: &mut DwgMergedReader, version: DwgVersio
         }
     }
 
-    let boundary_handle_count = reader.read_bit_long();
+    // Cap the boundary-handle count to a sane upper bound. Corrupt /
+    // misaligned hatch records have been seen to emit ~1.9 × 10^9 here,
+    // which spins read_handle() for tens of seconds per record. AutoCAD
+    // hatches realistically carry well under MAX_ARRAY_COUNT (100k)
+    // associative boundary references.
+    let boundary_handle_count = safe_count(reader.read_bit_long());
 
     HatchBoundaryPath { flags, edges, polyline_vertices, polyline_closed, boundary_handle_count }
 }


### PR DESCRIPTION
## Summary

`read_hatch_boundary_path` reads `boundary_handle_count` directly from `reader.read_bit_long()` without `safe_count`. A corrupt or misaligned hatch record can emit a near-`INT_MAX` value (observed ~1.9 × 10⁹ on a real DWG); the downstream `for _ in 0..count { reader.read_handle() }` then spins for tens of seconds per record. A 2.5 MB file with ~16 such records took >100 s to parse and looked completely hung. The same file now parses in ~0.7 s release / ~2.8 s debug.

## Change

Wrap the read with the existing `safe_count` (`MAX_ARRAY_COUNT = 100k`), matching how every other count in `read_hatch_boundary_path` and `read_hatch` is handled. A real-world AutoCAD hatch carries well under that limit; values above it can only be parse errors.

## Test plan
- [x] Confirmed parse goes from >100 s to ~0.7 s on the reproducing file
- [x] cargo check / cargo test on the workspace passes
- [x] No behaviour change for hatches whose `boundary_handle_count` ≤ 100k (the vast majority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)