### PR TITLE
fix(dwg): keep raster-image/wipeout clip boundary vertices

### DIFF
--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -1773,6 +1773,23 @@ impl DwgDocumentBuilder {
                     e.brightness = data.brightness;
                     e.contrast = data.contrast;
                     e.fade = data.fade;
+                    // Propagate clip boundary the same way Wipeout does — the
+                    // parser used to discard the vertices, leaving the default
+                    // boundary on the entity. Without this, clip regions
+                    // shrink/expand by orders of magnitude on render.
+                    e.clip_boundary = crate::entities::raster_image::ClipBoundary {
+                        clip_type: if data.clip_type == 1 {
+                            crate::entities::raster_image::ClipType::Rectangular
+                        } else {
+                            crate::entities::raster_image::ClipType::Polygonal
+                        },
+                        clip_mode: if data.clip_inverted {
+                            crate::entities::raster_image::ClipMode::Inside
+                        } else {
+                            crate::entities::raster_image::ClipMode::Outside
+                        },
+                        vertices: data.clip_boundary_vertices,
+                    };
                     if data.definition_handle != 0 {
                         e.definition_handle = Some(Handle::from(data.definition_handle));
                     }
@@ -1797,6 +1814,12 @@ impl DwgDocumentBuilder {
                     e.brightness = data.brightness;
                     e.contrast = data.contrast;
                     e.fade = data.fade;
+                    e.clip_type = if data.clip_type == 1 {
+                        crate::entities::WipeoutClipType::Rectangular
+                    } else {
+                        crate::entities::WipeoutClipType::Polygonal
+                    };
+                    e.clip_boundary_vertices = data.clip_boundary_vertices;
                     if data.definition_handle != 0 {
                         e.definition_handle = Some(Handle::from(data.definition_handle));
                     }

--- a/src/io/dwg/dwg_stream_readers/object_reader/entities.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/entities.rs
@@ -1061,6 +1061,10 @@ pub struct RasterImageData {
     pub clip_type: i16,
     pub definition_handle: u64,
     pub reactor_handle: u64,
+    /// Clip boundary vertices in image pixel space (range 0..size for rect;
+    /// arbitrary polygon for polygonal). For rectangular clips two corners
+    /// are stored; for polygonal, three or more sequential vertices.
+    pub clip_boundary_vertices: Vec<Vector2>,
 }
 
 #[derive(Debug, Clone)]
@@ -1604,14 +1608,18 @@ pub fn read_raster_image(reader: &mut DwgMergedReader, version: DwgVersion) -> R
 
     // Clip boundary
     let clip_type = reader.read_bit_short();
+    let mut clip_boundary_vertices: Vec<Vector2> = Vec::new();
     if clip_type == 1 {
-        // Rectangular: 2 fixed vertices
-        let _pt1 = reader.read_2raw_double();
-        let _pt2 = reader.read_2raw_double();
+        // Rectangular: 2 opposite-corner vertices
+        clip_boundary_vertices.push(reader.read_2raw_double());
+        clip_boundary_vertices.push(reader.read_2raw_double());
     } else {
         // Polygonal
-        let n = safe_count(reader.read_bit_long());
-        for _ in 0..n { let _pt = reader.read_2raw_double(); }
+        let n = safe_count(reader.read_bit_long()) as usize;
+        clip_boundary_vertices.reserve(n);
+        for _ in 0..n {
+            clip_boundary_vertices.push(reader.read_2raw_double());
+        }
     }
 
     let definition_handle = reader.read_handle();
@@ -1621,6 +1629,7 @@ pub fn read_raster_image(reader: &mut DwgMergedReader, version: DwgVersion) -> R
         class_version, insertion_point, u_vector, v_vector, size,
         flags, clipping_enabled, brightness, contrast, fade, clip_inverted,
         clip_type, definition_handle, reactor_handle,
+        clip_boundary_vertices,
     }
 }
 


### PR DESCRIPTION
The DWG reader read clip-boundary points only to advance the bit
cursor — two raw doubles for rectangular, n raw doubles for polygonal —
and discarded them. Both `RasterImage` and `Wipeout` then carried the
`Wipeout::new()` / `RasterImage::new()` default `ClipBoundary`
(rectangular, [-0.5, 0.5]), which makes the clip rectangle span the
entire single-pixel placeholder rather than the much smaller polygon
the authoring tool actually stored.

For wipeouts the file's u_vector / v_vector cover an enormous bbox
(stored as the rectangle bounding the full clip + headroom), and the
authentic geometry lives entirely in the clip polygon — so the lost
vertices manifested as wipeouts rendering hundreds of times too large
versus AutoCAD in downstream consumers.

`RasterImageData` now carries the read vertices; the document builder
wires them into both `Wipeout.clip_boundary_vertices` and
`RasterImage.clip_boundary`, alongside the resolved clip type /
inversion flag.

Reproduced and verified with a real-world DWG (anteen.dwg) where
wipeouts went from rendering at ~643793-unit bbox to the intended
~1019x2127-unit polygon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)