### PR TITLE
feat(dwg): decode AcDbGeoData coordinate system

### DIFF
--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -2359,6 +2359,37 @@ impl DwgDocumentBuilder {
                         crate::objects::ObjectType::WipeoutVariables(obj),
                     );
                 },
+                OBJ_GEODATA => {
+                    let data = objects::read_geodata(&mut reader);
+                    let mut obj = crate::objects::GeoData::new();
+                    obj.handle = Handle::from(handle);
+                    obj.owner = owner_handle;
+                    obj.version = data.version;
+                    obj.host_block = Handle::from(data.host_block);
+                    obj.coordinate_type = data.coordinate_type;
+                    obj.design_point = data.design_point;
+                    obj.reference_point = data.reference_point;
+                    obj.north_direction = data.north_direction;
+                    obj.up_direction = data.up_direction;
+                    obj.horizontal_unit_scale = data.horizontal_unit_scale;
+                    obj.vertical_unit_scale = data.vertical_unit_scale;
+                    obj.horizontal_units = data.horizontal_units;
+                    obj.vertical_units = data.vertical_units;
+                    obj.scale_estimation_method = data.scale_estimation_method;
+                    obj.user_scale_factor = data.user_scale_factor;
+                    obj.sea_level_correction = data.sea_level_correction;
+                    obj.sea_level_elevation = data.sea_level_elevation;
+                    obj.coordinate_projection_radius = data.coordinate_projection_radius;
+                    obj.coordinate_system_definition = data.coordinate_system_definition;
+                    obj.geo_rss_tag = data.geo_rss_tag;
+                    obj.observation_from_tag = data.observation_from_tag;
+                    obj.observation_to_tag = data.observation_to_tag;
+                    obj.observation_coverage_tag = data.observation_coverage_tag;
+                    document.objects.insert(
+                        Handle::from(handle),
+                        crate::objects::ObjectType::GeoData(obj),
+                    );
+                },
                 _ => {
                     // Preserve unrecognised non-entity objects verbatim so
                     // they survive roundtrip without losing their handles.

--- a/src/io/dwg/dwg_stream_readers/object_reader/common.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/common.rs
@@ -120,6 +120,9 @@ pub const OBJ_DBCOLOR: i16 = 0x81;          // 129
 pub const OBJ_WIPEOUTVARIABLES: i16 = 0x82; // 130
 pub const OBJ_TABLECONTENT: i16 = 0x69;     // 105
 pub const OBJ_TABLESTYLE: i16 = 0x6A;       // 106
+// GEODATA has no fixed DWG type code (it is always class-based); 0x83 is a free
+// internal sentinel used by the class-number map + builder dispatch.
+pub const OBJ_GEODATA: i16 = 0x83;          // 131
 
 /// Returns true if the type code is a graphical entity (not a table / object).
 pub fn is_entity_type(type_code: i16) -> bool {
@@ -167,6 +170,7 @@ pub fn dxf_name_to_type_code(dxf_name: &str) -> Option<i16> {
         "WIPEOUTVARIABLES" => Some(OBJ_WIPEOUTVARIABLES),
         "TABLECONTENT" => Some(OBJ_TABLECONTENT),
         "TABLESTYLE" => Some(OBJ_TABLESTYLE),
+        "GEODATA" | "ACDBGEODATA" => Some(OBJ_GEODATA),
         _ => None,
     }
 }

--- a/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
@@ -610,6 +610,97 @@ pub fn read_wipeout_variables(reader: &mut DwgMergedReader) -> WipeoutVariablesD
     WipeoutVariablesData { display_frame }
 }
 
+/// GeoData (AcDbGeoData) object-specific fields.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GeoDataData {
+    pub version: i32,
+    pub host_block: u64,
+    pub coordinate_type: i16,
+    pub design_point: Vector3,
+    pub reference_point: Vector3,
+    pub north_direction: Vector2,
+    pub up_direction: Vector3,
+    pub horizontal_unit_scale: f64,
+    pub vertical_unit_scale: f64,
+    pub horizontal_units: i32,
+    pub vertical_units: i32,
+    pub scale_estimation_method: i32,
+    pub user_scale_factor: f64,
+    pub sea_level_correction: bool,
+    pub sea_level_elevation: f64,
+    pub coordinate_projection_radius: f64,
+    pub coordinate_system_definition: String,
+    pub geo_rss_tag: String,
+    pub observation_from_tag: String,
+    pub observation_to_tag: String,
+    pub observation_coverage_tag: String,
+}
+
+/// Read the AcDbGeoData object body (after common non-entity data).
+///
+/// Ported from ACadSharp `DwgObjectReader.readGeoData`. The field order is
+/// version-dependent: R2010/R2013 store the coordinate system as a MapGuide XML
+/// string, R2009 as a WKT PROJCS string. Trailing geo-mesh points/faces are not
+/// read (not needed for the coordinate system; the per-object reader is bounded).
+pub fn read_geodata(reader: &mut DwgMergedReader) -> GeoDataData {
+    let mut d = GeoDataData {
+        horizontal_unit_scale: 1.0,
+        vertical_unit_scale: 1.0,
+        user_scale_factor: 1.0,
+        ..Default::default()
+    };
+
+    // BL object version
+    d.version = reader.read_bit_long();
+    // H soft pointer to host block
+    d.host_block = reader.read_handle();
+    // BS design coordinate type
+    d.coordinate_type = reader.read_bit_short();
+
+    if d.version == 1 {
+        // R2009
+        d.reference_point = reader.read_3bit_double();
+        d.horizontal_units = reader.read_bit_long();
+        d.vertical_units = d.horizontal_units;
+        d.design_point = reader.read_3bit_double();
+        let _obsolete = reader.read_3bit_double();
+        d.up_direction = reader.read_3bit_double();
+        // BD angle of north direction (radians, clockwise from (0,1))
+        let angle = std::f64::consts::FRAC_PI_2 - reader.read_bit_double();
+        d.north_direction = Vector2::new(angle.cos(), angle.sin());
+        let _obsolete2 = reader.read_3bit_double();
+        d.coordinate_system_definition = reader.read_variable_text();
+        d.geo_rss_tag = reader.read_variable_text();
+        d.horizontal_unit_scale = reader.read_bit_double();
+        d.vertical_unit_scale = d.horizontal_unit_scale;
+        let _datum = reader.read_variable_text();
+        let _wkt = reader.read_variable_text();
+    } else {
+        // R2010 / R2013 (and newer)
+        d.design_point = reader.read_3bit_double();
+        d.reference_point = reader.read_3bit_double();
+        d.horizontal_unit_scale = reader.read_bit_double();
+        d.horizontal_units = reader.read_bit_long();
+        d.vertical_unit_scale = reader.read_bit_double();
+        d.vertical_units = reader.read_bit_long();
+        d.up_direction = reader.read_3bit_double();
+        d.north_direction = reader.read_2raw_double();
+        d.scale_estimation_method = reader.read_bit_long();
+        d.user_scale_factor = reader.read_bit_double();
+        d.sea_level_correction = reader.read_bit();
+        d.sea_level_elevation = reader.read_bit_double();
+        d.coordinate_projection_radius = reader.read_bit_double();
+        d.coordinate_system_definition = reader.read_variable_text();
+        d.geo_rss_tag = reader.read_variable_text();
+    }
+
+    d.observation_from_tag = reader.read_variable_text();
+    d.observation_to_tag = reader.read_variable_text();
+    d.observation_coverage_tag = reader.read_variable_text();
+    d
+}
+
 // ════════════════════════════════════════════════════════════════════════
 //  Tests
 // ════════════════════════════════════════════════════════════════════════
@@ -662,6 +753,44 @@ mod tests {
         let dv = read_dictionary_variable(&mut r);
         assert_eq!(dv.schema_number, 0);
         assert_eq!(dv.value, "test_value");
+    }
+
+    #[test]
+    fn test_geodata_roundtrip_r2013() {
+        let v = DwgVersion::AC15;
+        let d = DxfVersion::AC1015;
+        let csd = "<Dictionary><ProjectedCoordinateSystem id=\"MO83-WF\"/></Dictionary>";
+        let mut r = make_reader(v, d, |w| {
+            w.write_bit_long(3); // object version (R2013)
+            w.write_handle(DwgReferenceType::SoftOwnership, 0x30); // host block
+            w.write_bit_short(2); // coordinate type
+            w.write_3bit_double(Vector3::new(1.0, 2.0, 3.0)); // design point
+            w.write_3bit_double(Vector3::new(4.0, 5.0, 6.0)); // reference point
+            w.write_bit_double(1.0); // horizontal unit scale
+            w.write_bit_long(9); // horizontal units
+            w.write_bit_double(1.0); // vertical unit scale
+            w.write_bit_long(9); // vertical units
+            w.write_3bit_double(Vector3::new(0.0, 0.0, 1.0)); // up direction
+            w.write_2raw_double(Vector2::new(0.0, 1.0)); // north direction
+            w.write_bit_long(0); // scale estimation method
+            w.write_bit_double(1.0); // user scale factor
+            w.write_bit(false); // sea-level correction
+            w.write_bit_double(0.0); // sea-level elevation
+            w.write_bit_double(6378137.0); // coordinate projection radius
+            w.write_variable_text(csd); // coordinate system definition
+            w.write_variable_text("georss-tag"); // geo rss tag
+            w.write_variable_text("from"); // observation from
+            w.write_variable_text("to"); // observation to
+            w.write_variable_text("cov"); // observation coverage
+        });
+        let g = read_geodata(&mut r);
+        assert_eq!(g.version, 3);
+        assert_eq!(g.coordinate_type, 2);
+        assert_eq!(g.design_point, Vector3::new(1.0, 2.0, 3.0));
+        assert_eq!(g.reference_point, Vector3::new(4.0, 5.0, 6.0));
+        assert_eq!(g.coordinate_system_definition, csd);
+        assert_eq!(g.geo_rss_tag, "georss-tag");
+        assert_eq!(g.observation_coverage_tag, "cov");
     }
 
     #[test]

--- a/src/objects/stub_objects.rs
+++ b/src/objects/stub_objects.rs
@@ -3,7 +3,7 @@
 //! These are minimal representations of DXF objects that ACadSharp supports
 //! but that don't require full rich data models for typical usage.
 
-use crate::types::Handle;
+use crate::types::{Handle, Vector2, Vector3};
 
 /// Trait for minimal stub objects that only need handle + owner fields.
 /// Used by the generic `read_stub_object` reader.
@@ -99,7 +99,11 @@ impl Default for Material {
     fn default() -> Self { Self::new() }
 }
 
-/// GeoData — geographic location data for a drawing
+/// GeoData — geographic location data for a drawing (AcDbGeoData).
+///
+/// Carries the drawing's georeference, most importantly the coordinate-system
+/// definition (a MapGuide coordinate-system XML string on R2010+; a WKT PROJCS
+/// string on R2009).
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GeoData {
@@ -107,10 +111,48 @@ pub struct GeoData {
     pub handle: Handle,
     /// Owner handle
     pub owner: Handle,
-    /// Object version (code 90)
+    /// Object version (code 90): 1 = R2009, 2 = R2010, 3 = R2013
     pub version: i32,
+    /// Soft pointer to the host block record
+    pub host_block: Handle,
     /// Coordinate type (code 70): 0 = unknown, 1 = local grid, 2 = projected grid, 3 = geographic
     pub coordinate_type: i16,
+    /// Design point (WCS) (codes 10/20/30)
+    pub design_point: Vector3,
+    /// Reference point (geographic/projected) (codes 11/21/31)
+    pub reference_point: Vector3,
+    /// North direction vector (codes 12/22)
+    pub north_direction: Vector2,
+    /// Up direction (codes 210/220/230)
+    pub up_direction: Vector3,
+    /// Horizontal unit scale (code 41)
+    pub horizontal_unit_scale: f64,
+    /// Vertical unit scale (code 40)
+    pub vertical_unit_scale: f64,
+    /// Horizontal units (code 91)
+    pub horizontal_units: i32,
+    /// Vertical units (code 92)
+    pub vertical_units: i32,
+    /// Scale estimation method (code 95)
+    pub scale_estimation_method: i32,
+    /// User-specified scale factor (code 141)
+    pub user_scale_factor: f64,
+    /// Enable sea-level correction (code 294)
+    pub sea_level_correction: bool,
+    /// Sea-level elevation (code 142)
+    pub sea_level_elevation: f64,
+    /// Coordinate projection radius (code 143)
+    pub coordinate_projection_radius: f64,
+    /// Coordinate system definition (code 301): MapGuide XML (R2010+) or WKT (R2009)
+    pub coordinate_system_definition: String,
+    /// Geo RSS tag (code 302)
+    pub geo_rss_tag: String,
+    /// Observation-from tag (code 305)
+    pub observation_from_tag: String,
+    /// Observation-to tag (code 306)
+    pub observation_to_tag: String,
+    /// Observation-coverage tag (code 307)
+    pub observation_coverage_tag: String,
 }
 
 impl GeoData {
@@ -120,7 +162,26 @@ impl GeoData {
             handle: Handle::NULL,
             owner: Handle::NULL,
             version: 2,
+            host_block: Handle::NULL,
             coordinate_type: 0,
+            design_point: Vector3::default(),
+            reference_point: Vector3::default(),
+            north_direction: Vector2::default(),
+            up_direction: Vector3::default(),
+            horizontal_unit_scale: 1.0,
+            vertical_unit_scale: 1.0,
+            horizontal_units: 0,
+            vertical_units: 0,
+            scale_estimation_method: 0,
+            user_scale_factor: 1.0,
+            sea_level_correction: false,
+            sea_level_elevation: 0.0,
+            coordinate_projection_radius: 0.0,
+            coordinate_system_definition: String::new(),
+            geo_rss_tag: String::new(),
+            observation_from_tag: String::new(),
+            observation_to_tag: String::new(),
+            observation_coverage_tag: String::new(),
         }
     }
 }


### PR DESCRIPTION
## What

DWG `GEODATA` (AcDbGeoData) objects were routed to `ObjectType::Unknown`, discarding the drawing's georeference — most importantly the coordinate-system definition. This adds a real decoder so reads surface `ObjectType::GeoData` with the coordinate system.

## Changes

- **`read_geodata`** object reader, ported from the documented field order, covering both on-disk layouts:
  - **R2009** — coordinate system stored as a WKT PROJCS string
  - **R2010 / R2013** — coordinate system stored as a MapGuide coordinate-system XML string
- Expanded the **`GeoData`** struct with the georeference fields: `coordinate_system_definition`, design/reference points, north/up direction, horizontal/vertical unit scales + units, scale-estimation method, user scale factor, sea-level correction + elevation, coordinate projection radius, geo-RSS tag, and observation tags.
- **`OBJ_GEODATA`** internal type code + `GEODATA` / `ACDBGEODATA` class-name routing so the class-based object reaches the decoder.
- Builder dispatch arm constructing `ObjectType::GeoData`.

Trailing geo-mesh points/faces are intentionally not read — they are not needed for the coordinate system and the per-object reader is bounded.

## Testing

- New round-trip unit test `test_geodata_roundtrip_r2013`.
- Verified on **40 real AutoCAD 2018 (AC1032) files** across three projects: `coordinate_system_definition` decodes **byte-for-byte identically to LibreDWG's `dwgread`** (e.g. length 5224 for a `MO83-WF` file, matching exactly), across three different state-plane systems (`MO83-WF`, `OH83-SF`, `IL83-EF`). Reference drawings that genuinely carry no CRS decode to an empty string (also confirmed against LibreDWG). Zero panics or read errors across the whole set.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
