### PR TITLE
Transform & mirror fidelity, AC18 section-name fix, dynamic-block visibility parsing (Phase 2 of #24)

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -573,6 +573,10 @@ pub struct HeaderVariables {
     pub current_text_style_name: String,
     /// DIMSTYLE - Current dimension style name
     pub current_dimstyle_name: String,
+    /// CTABLESTYLE - Current table style name
+    pub current_table_style_name: String,
+    /// CMLEADERSTYLE - Current multileader style name
+    pub current_mleader_style_name: String,
 }
 
 impl Default for HeaderVariables {
@@ -861,6 +865,8 @@ impl Default for HeaderVariables {
             current_layer_name: String::from("0"),
             current_text_style_name: String::from("Standard"),
             current_dimstyle_name: String::from("Standard"),
+            current_table_style_name: String::from("Standard"),
+            current_mleader_style_name: String::from("Standard"),
         }
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -930,6 +930,20 @@ pub struct CadDocument {
     /// All objects in the document (indexed by handle)
     pub objects: HashMap<Handle, ObjectType>,
 
+    /// Parsed dynamic-block visibility parameters, keyed by parameter handle.
+    /// A *side* view: the objects themselves are still kept verbatim in
+    /// `objects` as `ObjectType::Unknown` for DWG round-trip. Lets consumers
+    /// enumerate visibility states and their per-state visible-entity sets
+    /// without re-decoding the raw object stream.
+    pub block_visibility_params: HashMap<Handle, crate::objects::BlockVisibilityParameter>,
+
+    /// AcDbBlockRepresentationData link: representation-object handle → the
+    /// dynamic block-definition handle it represents (group code 340). Lets a
+    /// consumer connect an anonymous evaluated block to its dynamic definition
+    /// (and thus to that definition's visibility parameter). Side view; the
+    /// objects stay verbatim as `ObjectType::Unknown`.
+    pub block_representations: HashMap<Handle, Handle>,
+
     /// Raw EED blobs per handle — populated during DWG read, consumed during DWG write.
     /// Keyed by the object/table-entry handle. Not serialized.
     pub(crate) eed_by_handle: HashMap<Handle, Vec<(u64, Vec<u8>)>>,
@@ -970,6 +984,8 @@ impl CadDocument {
             entities: Vec::new(),
             entity_index: HashMap::new(),
             objects: HashMap::new(),
+            block_visibility_params: HashMap::new(),
+            block_representations: HashMap::new(),
             eed_by_handle: HashMap::new(),
             xdic_by_handle: HashMap::new(),
             reactors_by_handle: HashMap::new(),
@@ -1645,6 +1661,70 @@ impl CadDocument {
     /// Iterate over all entities mutably
     pub fn entities_mut(&mut self) -> impl Iterator<Item = &mut EntityType> {
         self.entities.iter_mut()
+    }
+
+    /// Owner handle of a dictionary/unknown object, for ownership-chain walks.
+    fn object_owner(&self, h: Handle) -> Option<Handle> {
+        match self.objects.get(&h)? {
+            ObjectType::Dictionary(d) => Some(d.owner),
+            ObjectType::DictionaryWithDefault(_) => None,
+            ObjectType::Unknown { owner, .. } => Some(*owner),
+            _ => None,
+        }
+    }
+
+    /// Walk the ownership chain upward from `start` (inclusive) and report
+    /// whether it passes through `target`. Bounded to avoid cycles.
+    fn owner_chain_reaches(&self, start: Handle, target: Handle) -> bool {
+        let mut cur = start;
+        for _ in 0..16 {
+            if cur == target {
+                return true;
+            }
+            match self.object_owner(cur) {
+                Some(next) if next != cur && next.value() != 0 => cur = next,
+                _ => break,
+            }
+        }
+        cur == target
+    }
+
+    /// Resolve the visibility parameter governing a dynamic block definition,
+    /// if that block carries one (via its ACAD_ENHANCEDBLOCK evaluation graph).
+    pub fn block_visibility_param_for_def(
+        &self,
+        def_block: Handle,
+    ) -> Option<&crate::objects::BlockVisibilityParameter> {
+        self.block_visibility_params
+            .values()
+            .find(|p| self.owner_chain_reaches(p.owner, def_block))
+    }
+
+    /// Resolve the dynamic visibility parameter for a block reference (INSERT),
+    /// returning `(dynamic_definition_block, parameter)`.
+    ///
+    /// An evaluated (anonymous) block reference records its dynamic definition
+    /// through an `AcDbBlockRepresentationData` object reachable from the
+    /// INSERT's extension dictionary. That definition's enhanced-block graph
+    /// then carries the visibility parameter.
+    pub fn dynamic_visibility_for_insert(
+        &self,
+        insert_handle: Handle,
+    ) -> Option<(Handle, &crate::objects::BlockVisibilityParameter)> {
+        let insert = self.entities.iter().find_map(|e| match e {
+            EntityType::Insert(i) if i.common.handle == insert_handle => Some(i),
+            _ => None,
+        })?;
+        let xdict = insert.common.xdictionary_handle?;
+        // Find the representation object owned (transitively) by this INSERT's
+        // extension dictionary; it names the dynamic definition block.
+        let def_block = self
+            .block_representations
+            .iter()
+            .find(|(rep, _)| self.owner_chain_reaches(**rep, xdict))
+            .map(|(_, def)| *def)?;
+        let param = self.block_visibility_param_for_def(def_block)?;
+        Some((def_block, param))
     }
 
     /// Resolve handle references after reading a DXF file.

--- a/src/entities/acis/sab.rs
+++ b/src/entities/acis/sab.rs
@@ -49,6 +49,9 @@ pub mod tags {
     pub const POSITION: u8 = 0x13;
     /// Direction (3 doubles: x, y, z).
     pub const DIRECTION: u8 = 0x14;
+    /// Enumerated value (4-byte int). Emitted by ASM / ShapeManager records
+    /// (AutoCAD 2013+); read like an integer.
+    pub const ENUM: u8 = 0x15;
 }
 
 /// SAB header magic string.
@@ -485,14 +488,19 @@ pub struct SabReader;
 impl SabReader {
     /// Parse SAB binary data into a SAT document.
     pub fn read(data: &[u8]) -> Result<SatDocument, SabError> {
-        if data.len() < SAB_MAGIC.len() {
+        // Two header magics: classic ACIS ("ACIS BinaryFile", 15 bytes) and the
+        // newer Autodesk ShapeManager ("ASM BinaryFile", 14 bytes) emitted by
+        // AutoCAD 2013+ and carried in the AcDs data store. In both the version
+        // u32 begins 15 bytes in: ACIS's magic is 15 bytes; ASM's 14-byte magic
+        // is followed by one trailing byte before the header ints.
+        const SAB_MAGIC_ASM: &[u8] = b"ASM BinaryFile";
+        let mut pos = if data.starts_with(SAB_MAGIC) {
+            SAB_MAGIC.len()
+        } else if data.starts_with(SAB_MAGIC_ASM) {
+            SAB_MAGIC.len() // 15 = 14-byte ASM magic + 1 trailing byte
+        } else {
             return Err(SabError::InvalidMagic);
-        }
-        if &data[..SAB_MAGIC.len()] != SAB_MAGIC {
-            return Err(SabError::InvalidMagic);
-        }
-
-        let mut pos = SAB_MAGIC.len();
+        };
 
         // Header ints (4 × u32 LE)
         let version_num = read_u32(data, &mut pos)?;
@@ -734,7 +742,7 @@ impl SabReader {
                 let val = read_i32(data, &mut pos)?;
                 Ok((SatToken::Pointer(SatPointer::new(val)), pos))
             }
-            tags::INTEGER => {
+            tags::INTEGER | tags::ENUM => {
                 let val = read_i32(data, &mut pos)?;
                 Ok((SatToken::Integer(val as i64), pos))
             }

--- a/src/entities/acis/types.rs
+++ b/src/entities/acis/types.rs
@@ -368,6 +368,19 @@ impl SatRecord {
         self.tokens.get(index).and_then(|t| t.as_pointer())
     }
 
+    /// Pointer by ordinal: the `index`-th pointer token, skipping interleaved
+    /// scalar tokens. Most accessors use absolute positions (`token_pointer`)
+    /// because ACIS keeps parameters in fixed slots, but a few records gained
+    /// an extra scalar field in ASM (ShapeManager, AutoCAD 2013+) — e.g. a
+    /// vertex's tolerance int between its edge and point — where ordinal
+    /// indexing stays correct for both ACIS and ASM.
+    pub fn nth_pointer(&self, index: usize) -> Option<SatPointer> {
+        self.tokens
+            .iter()
+            .filter_map(|t| t.as_pointer())
+            .nth(index)
+    }
+
     /// Returns the string value at the given token position.
     pub fn token_string(&self, index: usize) -> Option<&str> {
         self.tokens.get(index).and_then(|t| match t {
@@ -803,12 +816,16 @@ impl<'a> SatVertex<'a> {
 
     /// Pointer to the edge.
     pub fn edge(&self) -> SatPointer {
-        self.record.token_pointer(1).unwrap_or(SatPointer::NULL)
+        self.record.nth_pointer(1).unwrap_or(SatPointer::NULL)
     }
 
     /// Pointer to the point geometry.
+    ///
+    /// Uses pointer-ordinal indexing so the ASM (AutoCAD 2013+) vertex layout
+    /// `$attr $edge <tolerance:int> $point` resolves the same as the classic
+    /// ACIS `$attr $edge $point`.
     pub fn point(&self) -> SatPointer {
-        self.record.token_pointer(2).unwrap_or(SatPointer::NULL)
+        self.record.nth_pointer(2).unwrap_or(SatPointer::NULL)
     }
 }
 

--- a/src/entities/acis/types.rs
+++ b/src/entities/acis/types.rs
@@ -360,7 +360,29 @@ impl SatRecord {
 
     /// Returns the float value of the token at the given position.
     pub fn token_float(&self, index: usize) -> Option<f64> {
-        self.tokens.get(index).and_then(|t| t.as_float())
+        // Coordinate-aware flat-float indexing. SAT text stores a point/vector
+        // as three separate float tokens, so the geometry accessors read
+        // px,py,pz / nx,ny,nz at consecutive indices. SAB/ASM (AutoCAD 2013+)
+        // packs each coordinate triple into ONE Position/Direction token, so
+        // expand those into three consecutive float slots here. Records with
+        // no Position tokens (all SAT, most SAB scalars) index 1:1 as before.
+        let mut slot = 0usize;
+        for t in &self.tokens {
+            if let SatToken::Position(x, y, z) = t {
+                for &c in &[*x, *y, *z] {
+                    if slot == index {
+                        return Some(c);
+                    }
+                    slot += 1;
+                }
+            } else {
+                if slot == index {
+                    return t.as_float();
+                }
+                slot += 1;
+            }
+        }
+        None
     }
 
     /// Returns the pointer at the given token position.

--- a/src/entities/insert.rs
+++ b/src/entities/insert.rs
@@ -389,10 +389,13 @@ impl Insert {
 
             // Circle → Ellipse so non-uniform scale works
             EntityType::Circle(circle) => {
+                // CIRCLE stores `center` in OCS; ELLIPSE is a WCS entity —
+                // convert on the way in (identity for the Z-up normal).
+                let ocs_to_wcs = Matrix3::arbitrary_axis(circle.normal);
                 let mut ellipse = Ellipse {
                     common: circle.common.clone(),
-                    center: circle.center,
-                    major_axis: Vector3::UNIT_X * circle.radius,
+                    center: ocs_to_wcs * circle.center,
+                    major_axis: ocs_to_wcs * (Vector3::UNIT_X * circle.radius),
                     minor_axis_ratio: 1.0,
                     start_parameter: 0.0,
                     end_parameter: std::f64::consts::TAU,
@@ -491,10 +494,15 @@ impl Insert {
 
     /// Explode an arc with non-uniform XY scale — converts to an elliptical arc (Ellipse).
     fn explode_arc_to_ellipse(&self, arc: &Arc, transform: &Transform) -> EntityType {
+        // ARC stores `center` in OCS; ELLIPSE is a WCS entity. Convert on the
+        // way in (identity for the common Z-up normal). The arc's angles are
+        // measured against the OCS X axis, which becomes the ellipse's major
+        // axis below — so the parameters carry over unchanged.
+        let ocs_to_wcs = Matrix3::arbitrary_axis(arc.normal);
         let mut ellipse = Ellipse {
             common: arc.common.clone(),
-            center: arc.center,
-            major_axis: Vector3::UNIT_X * arc.radius,
+            center: ocs_to_wcs * arc.center,
+            major_axis: ocs_to_wcs * (Vector3::UNIT_X * arc.radius),
             minor_axis_ratio: 1.0,
             start_parameter: arc.start_angle,
             end_parameter: arc.end_angle,
@@ -511,17 +519,18 @@ impl Insert {
     /// unchanged), this properly computes the new ratio by transforming both
     /// major and minor axis directions independently. The new normal is derived
     /// from `new_major × new_minor`, which automatically encodes any handedness
-    /// flip introduced by a reflective transform (det < 0). The stored
-    /// `major_axis` is then expressed in the new ellipse's OCS so the renderer
-    /// reconstructs the correct WCS direction together with the derived normal,
-    /// preserving the original sweep direction.
+    /// flip introduced by a reflective transform (det < 0), preserving the
+    /// original sweep direction.
+    ///
+    /// ELLIPSE is one of the few WCS entities in DXF: `center` (code 10) and
+    /// `major_axis` (code 11) are world coordinates, NOT OCS — so the transform
+    /// applies to the stored values directly and the results are stored back
+    /// as-is. (An earlier revision round-tripped them through the
+    /// arbitrary-axis OCS, which made files with a non-Z-up result — e.g. a
+    /// mirrored explode — read wrong in other CAD applications.)
     fn apply_full_ellipse_transform(ellipse: &mut Ellipse, transform: &Transform) {
-        // Convert center and major axis (both stored in OCS per the arbitrary-axis
-        // algorithm) to WCS so the INSERT transform can be applied uniformly.
-        // For normal=(0,0,1) OCS == WCS and these conversions are no-ops.
-        let ocs_to_wcs = Matrix3::arbitrary_axis(ellipse.normal);
-        let center_wcs = ocs_to_wcs * ellipse.center;
-        let major_wcs = ocs_to_wcs * ellipse.major_axis;
+        let center_wcs = ellipse.center;
+        let major_wcs = ellipse.major_axis;
 
         // Original minor axis vector (WCS, perpendicular to major in the ellipse plane).
         let original_minor_dir = ellipse.normal.cross(&major_wcs).normalize();
@@ -558,16 +567,8 @@ impl Insert {
             Self::transform_normal(transform, ellipse.normal)
         };
 
-        // Re-express center and major axis in the new OCS so the renderer
-        // (which interprets `center` and `major_axis` components in OCS)
-        // reconstructs the correct WCS values.
-        let new_ocs_to_wcs = Matrix3::arbitrary_axis(new_normal);
-        let new_wcs_to_ocs = new_ocs_to_wcs.transpose();
-        let center_ocs = new_wcs_to_ocs * new_center_wcs;
-        let major_ocs = new_wcs_to_ocs * final_major_wcs;
-
-        ellipse.center = center_ocs;
-        ellipse.major_axis = major_ocs;
+        ellipse.center = new_center_wcs;
+        ellipse.major_axis = final_major_wcs;
         ellipse.minor_axis_ratio = if final_major_wcs.length() > 1e-12 {
             final_minor_wcs.length() / final_major_wcs.length()
         } else {
@@ -1346,11 +1347,10 @@ mod tests {
     // ── Mirrored INSERT ellipse handedness ──────────────────────
 
     /// Reconstruct an ellipse's three sample points at t = start, mid, end in WCS.
-    /// Both `center` and `major_axis` are interpreted as OCS (arbitrary-axis algorithm).
+    /// ELLIPSE is a WCS entity: `center` and `major_axis` are world coordinates.
     fn ellipse_sample_points(e: &Ellipse) -> (Vector3, Vector3, Vector3) {
-        let basis = Matrix3::arbitrary_axis(e.normal);
-        let center_wcs = basis * e.center;
-        let major_wcs = basis * e.major_axis;
+        let center_wcs = e.center;
+        let major_wcs = e.major_axis;
         let major_len = major_wcs.length();
         let u = major_wcs * (1.0 / major_len.max(1e-12));
         let v = e.normal.cross(&u);

--- a/src/entities/mirror.rs
+++ b/src/entities/mirror.rs
@@ -43,19 +43,17 @@ pub(crate) fn mirror_ellipse(e: &mut Ellipse, transform: &Transform) {
 // ── LwPolyline ───────────────────────────────────────────────────────────────
 
 pub(crate) fn mirror_lwpolyline(e: &mut LwPolyline, transform: &Transform) {
+    // transform_lwpolyline negates bulges itself whenever the transform
+    // reflects (det < 0) — no extra post-processing needed.
     super::transform::transform_lwpolyline(e, transform);
-    for vertex in &mut e.vertices {
-        vertex.bulge = -vertex.bulge;
-    }
 }
 
 // ── Polyline (3D heavy) ──────────────────────────────────────────────────────
 
 pub(crate) fn mirror_polyline2d(e: &mut Polyline2D, transform: &Transform) {
+    // transform_polyline2d negates bulges itself whenever the transform
+    // reflects (det < 0) — no extra post-processing needed.
     super::transform::transform_polyline2d(e, transform);
-    for vertex in &mut e.vertices {
-        vertex.bulge = -vertex.bulge;
-    }
 }
 
 // ── Face3D ───────────────────────────────────────────────────────────────────
@@ -123,53 +121,12 @@ pub(crate) fn mirror_shape(e: &mut Shape, transform: &Transform) {
 // ── Hatch ────────────────────────────────────────────────────────────────────
 
 pub(crate) fn mirror_hatch(e: &mut Hatch, transform: &Transform) {
-    use crate::types::normalize_angle;
-
+    // transform_hatch handles reflections itself: it flips the boundary-arc
+    // direction flags, re-mirrors the stored angles and preserves the stored
+    // sweep (including wrap-encoded end angles above 2π). The old angle-swap
+    // post-processing here double-corrected on top of that and re-normalized
+    // the angles, breaking wrap-encoded arcs.
     super::transform::transform_hatch(e, transform);
-
-    for path in &mut e.paths {
-        for edge in &mut path.edges {
-            match edge {
-                BoundaryEdge::CircularArc(arc) => {
-                    let old_start = arc.start_angle;
-                    let old_end = arc.end_angle;
-
-                    let center_3d = Vector3::new(arc.center.x, arc.center.y, 0.0);
-                    let start_pt = Vector3::new(
-                        arc.center.x + arc.radius * old_start.cos(),
-                        arc.center.y + arc.radius * old_start.sin(),
-                        0.0,
-                    );
-                    let end_pt = Vector3::new(
-                        arc.center.x + arc.radius * old_end.cos(),
-                        arc.center.y + arc.radius * old_end.sin(),
-                        0.0,
-                    );
-                    let ms = transform.apply(start_pt);
-                    let me = transform.apply(end_pt);
-
-                    arc.start_angle =
-                        normalize_angle((me.y - center_3d.y).atan2(me.x - center_3d.x));
-                    arc.end_angle =
-                        normalize_angle((ms.y - center_3d.y).atan2(ms.x - center_3d.x));
-                    arc.counter_clockwise = !arc.counter_clockwise;
-                }
-                BoundaryEdge::EllipticArc(ellipse) => {
-                    let new_start = -ellipse.end_angle;
-                    let new_end = -ellipse.start_angle;
-                    ellipse.start_angle = new_start;
-                    ellipse.end_angle = new_end;
-                    ellipse.counter_clockwise = !ellipse.counter_clockwise;
-                }
-                BoundaryEdge::Polyline(poly) => {
-                    for v in &mut poly.vertices {
-                        v.z = -v.z;
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
 }
 
 // ── EntityType dispatch ──────────────────────────────────────────────────────

--- a/src/entities/transform.rs
+++ b/src/entities/transform.rs
@@ -200,29 +200,40 @@ pub(crate) fn transform_hatch(e: &mut Hatch, transform: &Transform) {
                     line.end = transform_ocs_point(line.end);
                 }
                 BoundaryEdge::CircularArc(arc) => {
-                    // DXF stores the angles of a clockwise (ccw = false)
-                    // boundary arc MIRRORED: the true point is
-                    // `center + r·(cos(-θ), sin(-θ))` (verified against
-                    // AutoCAD output by endpoint continuity with adjacent
-                    // edges). Work in TRUE angle space — un-mirror, apply the
-                    // transform, then re-mirror for the new direction flag —
-                    // so both a flip (mirror INSERT) and a plain rotation of a
-                    // CW arc store convention-correct angles.
+                    // Stored-angle convention for boundary arcs, verified
+                    // against real AutoCAD output:
+                    //
+                    // 1. A clockwise (ccw = false) edge stores MIRRORED angles —
+                    //    the true point is `center + r·(cos(-θ), sin(-θ))`
+                    //    (endpoint continuity with adjacent edges: Δ = 0.0).
+                    // 2. The stored sweep is ALWAYS forward: `end - start ≥ 0`.
+                    //    When the arc crosses the 0 axis, AutoCAD writes `end`
+                    //    ABOVE 2π (e.g. start 5.81 → end 6.64). Normalizing the
+                    //    angles into [0, 2π) silently turns that 0.83 rad arc
+                    //    into its 5.46 rad complement — the giant wrong-way
+                    //    arcs this function used to produce via
+                    //    `transform_ocs_angle`'s atan2 normalization.
+                    //
+                    // So: transform only the START angle (one point, modulo is
+                    // fine) in TRUE angle space, and carry the stored sweep over
+                    // unchanged. The sweep is invariant under both rotation and
+                    // flip: a flip negates the true sweep AND mirrors the stored
+                    // space, which cancel.
                     let to_true = |a: f64, ccw: bool| if ccw { a } else { -a };
                     let norm = |a: f64| a.rem_euclid(2.0 * std::f64::consts::PI);
+                    let stored_sweep = arc.end_angle - arc.start_angle;
                     let true_start = to_true(arc.start_angle, arc.counter_clockwise);
-                    let true_end = to_true(arc.end_angle, arc.counter_clockwise);
                     let new_ccw = arc.counter_clockwise ^ is_flipped;
                     let center = transform_ocs_point(arc.center);
 
                     if is_uniform {
                         let new_true_start = transform_ocs_angle(true_start);
-                        let new_true_end = transform_ocs_angle(true_end);
+                        let new_start = norm(to_true(new_true_start, new_ccw));
                         arc.center = center;
                         arc.radius *= scale_x;
                         arc.counter_clockwise = new_ccw;
-                        arc.start_angle = norm(to_true(new_true_start, new_ccw));
-                        arc.end_angle = norm(to_true(new_true_end, new_ccw));
+                        arc.start_angle = new_start;
+                        arc.end_angle = new_start + stored_sweep;
                     } else {
                         let major_axis_wcs = trans_ocs_x_wcs * arc.radius;
                         let major_axis_ocs_3d = new_wcs_to_ocs * major_axis_wcs;
@@ -231,38 +242,32 @@ pub(crate) fn transform_hatch(e: &mut Hatch, transform: &Transform) {
 
                         // The ellipse parameter equals the circle's TRUE angle:
                         // the transformed axes carry the deformation, so the
-                        // parameter itself is unchanged — only re-mirrored for
-                        // the new direction flag.
-                        let mut ellipse = EllipticArcEdge {
-                            center,
-                            major_axis_endpoint,
-                            minor_axis_ratio: scale_y / scale_x,
-                            start_angle: norm(to_true(true_start, new_ccw)),
-                            end_angle: norm(to_true(true_end, new_ccw)),
-                            counter_clockwise: new_ccw,
-                        };
-
-                        if ellipse.minor_axis_ratio > 1.0 {
-                            let old_major = ellipse.major_axis_endpoint;
-                            let old_major_len = old_major.length();
-                            let new_major_len = old_major_len * ellipse.minor_axis_ratio;
-                            let new_major_dir =
-                                Vector2::new(-old_major.y, old_major.x).normalize();
-                            ellipse.major_axis_endpoint = new_major_dir * new_major_len;
-                            ellipse.minor_axis_ratio = 1.0 / ellipse.minor_axis_ratio;
+                        // parameter is unchanged — only re-mirrored for the new
+                        // direction flag, with the stored sweep carried over.
+                        let mut start = norm(to_true(true_start, new_ccw));
+                        let mut ratio = scale_y / scale_x;
+                        let mut major = major_axis_endpoint;
+                        if ratio > 1.0 {
+                            let len = major.length() * ratio;
+                            major = Vector2::new(-major.y, major.x).normalize() * len;
+                            ratio = 1.0 / ratio;
                             // Major axis rotated +90°: true parameter shifts by
-                            // -π/2; in stored (possibly mirrored) space that is
-                            // ∓π/2 depending on the direction flag.
-                            let shift = if ellipse.counter_clockwise {
+                            // -π/2; stored space mirrors that for CW edges.
+                            let shift = if new_ccw {
                                 -std::f64::consts::FRAC_PI_2
                             } else {
                                 std::f64::consts::FRAC_PI_2
                             };
-                            ellipse.start_angle = norm(ellipse.start_angle + shift);
-                            ellipse.end_angle = norm(ellipse.end_angle + shift);
+                            start = norm(start + shift);
                         }
-
-                        *edge = BoundaryEdge::EllipticArc(ellipse);
+                        *edge = BoundaryEdge::EllipticArc(EllipticArcEdge {
+                            center,
+                            major_axis_endpoint: major,
+                            minor_axis_ratio: ratio,
+                            start_angle: start,
+                            end_angle: start + stored_sweep,
+                            counter_clockwise: new_ccw,
+                        });
                     }
                 }
                 BoundaryEdge::EllipticArc(ellipse) => {
@@ -302,18 +307,18 @@ pub(crate) fn transform_hatch(e: &mut Hatch, transform: &Transform) {
 
                     ellipse.center = center;
                     // Same stored-angle convention as CircularArc: CW edges
-                    // keep mirrored parameters. The transformed axes carry the
-                    // deformation, so the TRUE parameter is unchanged — only
-                    // re-mirrored when the direction flag flips.
+                    // keep mirrored parameters, and the stored sweep
+                    // (end - start ≥ 0, end may exceed 2π to encode a wrap)
+                    // must survive untouched. Transform only the start
+                    // parameter and carry the sweep over.
+                    let norm = |a: f64| a.rem_euclid(2.0 * std::f64::consts::PI);
+                    let stored_sweep = ellipse.end_angle - ellipse.start_angle;
                     if is_flipped {
-                        let norm = |a: f64| a.rem_euclid(2.0 * std::f64::consts::PI);
                         ellipse.counter_clockwise = !ellipse.counter_clockwise;
                         ellipse.start_angle = norm(-ellipse.start_angle);
-                        ellipse.end_angle = norm(-ellipse.end_angle);
                     }
 
                     if new_minor_len > new_major_len + 1e-12 {
-                        let norm = |a: f64| a.rem_euclid(2.0 * std::f64::consts::PI);
                         ellipse.major_axis_endpoint = new_minor_ocs;
                         ellipse.minor_axis_ratio = new_major_len / new_minor_len;
                         // True parameter shifts by -π/2 (major rotated +90°);
@@ -324,7 +329,7 @@ pub(crate) fn transform_hatch(e: &mut Hatch, transform: &Transform) {
                             std::f64::consts::FRAC_PI_2
                         };
                         ellipse.start_angle = norm(ellipse.start_angle + shift);
-                        ellipse.end_angle = norm(ellipse.end_angle + shift);
+                        ellipse.end_angle = ellipse.start_angle + stored_sweep;
                     } else {
                         ellipse.major_axis_endpoint = new_major_ocs;
                         ellipse.minor_axis_ratio = if new_major_len > 1e-12 {
@@ -332,6 +337,7 @@ pub(crate) fn transform_hatch(e: &mut Hatch, transform: &Transform) {
                         } else {
                             1.0
                         };
+                        ellipse.end_angle = ellipse.start_angle + stored_sweep;
                     }
                 }
                 BoundaryEdge::Spline(spline) => {
@@ -1021,6 +1027,51 @@ mod tests {
             (mx - (-1.0)).abs() < 1e-9 && (my - 1.0).abs() < 1e-9,
             "arc midpoint {:?} must be the mirror of (1,1) → (-1,1)",
             (mx, my)
+        );
+    }
+
+    // The stored sweep of a boundary arc is always forward (end - start ≥ 0)
+    // and AutoCAD encodes a wrap through 0 by writing `end` ABOVE 2π
+    // (e.g. start 5.81 → end 6.64 for a 0.83 rad arc). Any normalization of
+    // the angles into [0, 2π) flips such an arc into its huge complement —
+    // the regression seen in real survey DWGs. Translation must keep the
+    // angles bit-identical; a mirror must preserve the sweep magnitude.
+    #[test]
+    fn test_hatch_arc_wrap_sweep_survives_transform() {
+        use crate::entities::hatch::{BoundaryEdge, BoundaryPath, CircularArcEdge};
+        use crate::types::Vector2;
+
+        let mk = || {
+            let mut path = BoundaryPath::new();
+            path.edges.push(BoundaryEdge::CircularArc(CircularArcEdge {
+                center: Vector2::new(10.0, 5.0),
+                radius: 61.3,
+                start_angle: 5.80985,
+                end_angle: 6.63571, // > 2π: wrap-encoded short arc
+                counter_clockwise: false,
+            }));
+            let mut h = Hatch::new();
+            h.paths.push(path);
+            h
+        };
+
+        // Pure translation: angles must be untouched.
+        let mut h = mk();
+        transform_hatch(&mut h, &Transform::from_translation(Vector3::new(3.0, -2.0, 0.0)));
+        let BoundaryEdge::CircularArc(a) = &h.paths[0].edges[0] else { panic!() };
+        assert!((a.start_angle - 5.80985).abs() < 1e-9, "start changed: {}", a.start_angle);
+        assert!((a.end_angle - 6.63571).abs() < 1e-9, "end changed: {}", a.end_angle);
+        assert!(!a.counter_clockwise);
+
+        // Mirror: sweep magnitude must survive (0.82586), direction flag flips.
+        let mut h = mk();
+        transform_hatch(&mut h, &Transform::from_scaling(Vector3::new(-1.0, 1.0, 1.0)));
+        let BoundaryEdge::CircularArc(a) = &h.paths[0].edges[0] else { panic!() };
+        assert!(a.counter_clockwise, "mirror must flip the flag");
+        let sweep = a.end_angle - a.start_angle;
+        assert!(
+            (sweep - 0.82586).abs() < 1e-9,
+            "sweep must stay 0.82586, got {sweep}"
         );
     }
 }

--- a/src/entities/transform.rs
+++ b/src/entities/transform.rs
@@ -6,6 +6,21 @@
 use super::*;
 use crate::types::{Matrix3, Transform, Vector2, Vector3};
 
+
+/// True when `transform` reverses orientation (negative upper-3×3
+/// determinant — an odd number of mirrors). Plane-curve direction data
+/// (polyline bulges, hatch boundary arc flags) must flip with it.
+pub(crate) fn is_reflecting(transform: &Transform) -> bool {
+    let m = transform.matrix.m;
+    Matrix3::from_rows(
+        [m[0][0], m[0][1], m[0][2]],
+        [m[1][0], m[1][1], m[1][2]],
+        [m[2][0], m[2][1], m[2][2]],
+    )
+    .determinant()
+        < 0.0
+}
+
 // ── Point ────────────────────────────────────────────────────────────────────
 
 pub(crate) fn transform_point(e: &mut Point, transform: &Transform) {
@@ -66,8 +81,14 @@ pub(crate) fn transform_polyline(e: &mut Polyline, transform: &Transform) {
 // ── Polyline2D ───────────────────────────────────────────────────────────────
 
 pub(crate) fn transform_polyline2d(e: &mut Polyline2D, transform: &Transform) {
+    let flip = is_reflecting(transform);
     for vertex in &mut e.vertices {
         vertex.location = transform.apply(vertex.location);
+        if flip {
+            // Bulge encodes the arc's side/direction in the plane; a
+            // reflection reverses it.
+            vertex.bulge = -vertex.bulge;
+        }
     }
 }
 
@@ -82,11 +103,18 @@ pub(crate) fn transform_polyline3d(e: &mut Polyline3D, transform: &Transform) {
 // ── LwPolyline ───────────────────────────────────────────────────────────────
 
 pub(crate) fn transform_lwpolyline(e: &mut LwPolyline, transform: &Transform) {
+    let flip = is_reflecting(transform);
     for vertex in &mut e.vertices {
         let pt3d = Vector3::new(vertex.location.x, vertex.location.y, e.elevation);
         let transformed = transform.apply(pt3d);
         vertex.location.x = transformed.x;
         vertex.location.y = transformed.y;
+        if flip {
+            // Bulge encodes the arc's side/direction in the plane; a
+            // reflection reverses it. Without this, exploding a mirrored
+            // INSERT bows every bulged segment to the wrong side.
+            vertex.bulge = -vertex.bulge;
+        }
     }
     if !e.vertices.is_empty() {
         let pt3d = Vector3::new(0.0, 0.0, e.elevation);
@@ -1073,5 +1101,35 @@ mod tests {
             (sweep - 0.82586).abs() < 1e-9,
             "sweep must stay 0.82586, got {sweep}"
         );
+    }
+
+    // Exploding a mirrored INSERT routes plain entities through
+    // apply_transform → transform_lwpolyline. The bulge encodes which side
+    // the arc bows to; a reflection must negate it or every bulged segment
+    // bows the wrong way after EXPLODE.
+    #[test]
+    fn test_reflecting_transform_negates_lwpolyline_bulge() {
+        let mut lw = LwPolyline::new();
+        let mut v0 = LwVertex::new(crate::types::Vector2::new(0.0, 0.0));
+        v0.bulge = 0.5;
+        let mut v1 = LwVertex::new(crate::types::Vector2::new(10.0, 0.0));
+        v1.bulge = -0.3;
+        lw.add_vertex(v0);
+        lw.add_vertex(v1);
+
+        // Mirror across Y (x → -x): reflection, bulges must negate.
+        let mut a = lw.clone();
+        transform_lwpolyline(&mut a, &Transform::from_scaling(Vector3::new(-1.0, 1.0, 1.0)));
+        assert!((a.vertices[0].bulge - (-0.5)).abs() < 1e-12);
+        assert!((a.vertices[1].bulge - 0.3).abs() < 1e-12);
+
+        // Pure rotation (det > 0): bulges untouched.
+        let mut b = lw.clone();
+        transform_lwpolyline(
+            &mut b,
+            &Transform::from_rotation(Vector3::new(0.0, 0.0, 1.0), std::f64::consts::FRAC_PI_2),
+        );
+        assert!((b.vertices[0].bulge - 0.5).abs() < 1e-12);
+        assert!((b.vertices[1].bulge - (-0.3)).abs() < 1e-12);
     }
 }

--- a/src/entities/transform.rs
+++ b/src/entities/transform.rs
@@ -200,35 +200,47 @@ pub(crate) fn transform_hatch(e: &mut Hatch, transform: &Transform) {
                     line.end = transform_ocs_point(line.end);
                 }
                 BoundaryEdge::CircularArc(arc) => {
-                    let new_start = transform_ocs_angle(arc.start_angle);
-                    let new_end = transform_ocs_angle(arc.end_angle);
+                    // DXF stores the angles of a clockwise (ccw = false)
+                    // boundary arc MIRRORED: the true point is
+                    // `center + r·(cos(-θ), sin(-θ))` (verified against
+                    // AutoCAD output by endpoint continuity with adjacent
+                    // edges). Work in TRUE angle space — un-mirror, apply the
+                    // transform, then re-mirror for the new direction flag —
+                    // so both a flip (mirror INSERT) and a plain rotation of a
+                    // CW arc store convention-correct angles.
+                    let to_true = |a: f64, ccw: bool| if ccw { a } else { -a };
+                    let norm = |a: f64| a.rem_euclid(2.0 * std::f64::consts::PI);
+                    let true_start = to_true(arc.start_angle, arc.counter_clockwise);
+                    let true_end = to_true(arc.end_angle, arc.counter_clockwise);
+                    let new_ccw = arc.counter_clockwise ^ is_flipped;
                     let center = transform_ocs_point(arc.center);
 
                     if is_uniform {
+                        let new_true_start = transform_ocs_angle(true_start);
+                        let new_true_end = transform_ocs_angle(true_end);
                         arc.center = center;
                         arc.radius *= scale_x;
-                        if is_flipped {
-                            arc.counter_clockwise = !arc.counter_clockwise;
-                        }
-                        arc.start_angle = new_start;
-                        arc.end_angle = new_end;
+                        arc.counter_clockwise = new_ccw;
+                        arc.start_angle = norm(to_true(new_true_start, new_ccw));
+                        arc.end_angle = norm(to_true(new_true_end, new_ccw));
                     } else {
                         let major_axis_wcs = trans_ocs_x_wcs * arc.radius;
                         let major_axis_ocs_3d = new_wcs_to_ocs * major_axis_wcs;
                         let major_axis_endpoint =
                             Vector2::new(major_axis_ocs_3d.x, major_axis_ocs_3d.y);
 
+                        // The ellipse parameter equals the circle's TRUE angle:
+                        // the transformed axes carry the deformation, so the
+                        // parameter itself is unchanged — only re-mirrored for
+                        // the new direction flag.
                         let mut ellipse = EllipticArcEdge {
                             center,
                             major_axis_endpoint,
                             minor_axis_ratio: scale_y / scale_x,
-                            start_angle: arc.start_angle,
-                            end_angle: arc.end_angle,
-                            counter_clockwise: arc.counter_clockwise,
+                            start_angle: norm(to_true(true_start, new_ccw)),
+                            end_angle: norm(to_true(true_end, new_ccw)),
+                            counter_clockwise: new_ccw,
                         };
-                        if is_flipped {
-                            ellipse.counter_clockwise = !ellipse.counter_clockwise;
-                        }
 
                         if ellipse.minor_axis_ratio > 1.0 {
                             let old_major = ellipse.major_axis_endpoint;
@@ -238,8 +250,16 @@ pub(crate) fn transform_hatch(e: &mut Hatch, transform: &Transform) {
                                 Vector2::new(-old_major.y, old_major.x).normalize();
                             ellipse.major_axis_endpoint = new_major_dir * new_major_len;
                             ellipse.minor_axis_ratio = 1.0 / ellipse.minor_axis_ratio;
-                            ellipse.start_angle -= std::f64::consts::FRAC_PI_2;
-                            ellipse.end_angle -= std::f64::consts::FRAC_PI_2;
+                            // Major axis rotated +90°: true parameter shifts by
+                            // -π/2; in stored (possibly mirrored) space that is
+                            // ∓π/2 depending on the direction flag.
+                            let shift = if ellipse.counter_clockwise {
+                                -std::f64::consts::FRAC_PI_2
+                            } else {
+                                std::f64::consts::FRAC_PI_2
+                            };
+                            ellipse.start_angle = norm(ellipse.start_angle + shift);
+                            ellipse.end_angle = norm(ellipse.end_angle + shift);
                         }
 
                         *edge = BoundaryEdge::EllipticArc(ellipse);
@@ -281,15 +301,30 @@ pub(crate) fn transform_hatch(e: &mut Hatch, transform: &Transform) {
                     let new_minor_len = new_minor_ocs.length();
 
                     ellipse.center = center;
+                    // Same stored-angle convention as CircularArc: CW edges
+                    // keep mirrored parameters. The transformed axes carry the
+                    // deformation, so the TRUE parameter is unchanged — only
+                    // re-mirrored when the direction flag flips.
                     if is_flipped {
+                        let norm = |a: f64| a.rem_euclid(2.0 * std::f64::consts::PI);
                         ellipse.counter_clockwise = !ellipse.counter_clockwise;
+                        ellipse.start_angle = norm(-ellipse.start_angle);
+                        ellipse.end_angle = norm(-ellipse.end_angle);
                     }
 
                     if new_minor_len > new_major_len + 1e-12 {
+                        let norm = |a: f64| a.rem_euclid(2.0 * std::f64::consts::PI);
                         ellipse.major_axis_endpoint = new_minor_ocs;
                         ellipse.minor_axis_ratio = new_major_len / new_minor_len;
-                        ellipse.start_angle -= std::f64::consts::FRAC_PI_2;
-                        ellipse.end_angle -= std::f64::consts::FRAC_PI_2;
+                        // True parameter shifts by -π/2 (major rotated +90°);
+                        // stored space mirrors that for CW edges.
+                        let shift = if ellipse.counter_clockwise {
+                            -std::f64::consts::FRAC_PI_2
+                        } else {
+                            std::f64::consts::FRAC_PI_2
+                        };
+                        ellipse.start_angle = norm(ellipse.start_angle + shift);
+                        ellipse.end_angle = norm(ellipse.end_angle + shift);
                     } else {
                         ellipse.major_axis_endpoint = new_major_ocs;
                         ellipse.minor_axis_ratio = if new_major_len > 1e-12 {
@@ -906,5 +941,86 @@ mod tests {
         } else {
             panic!("Expected Circle");
         }
+    }
+
+    // Mirroring a hatch must keep its boundary arc edges continuous with the
+    // adjacent line edges. DXF stores CW (ccw=false) arc-edge angles MIRRORED
+    // — the true point is center + r·(cos(-θ), sin(-θ)) — verified against
+    // AutoCAD output by endpoint continuity. The old code stored geometric
+    // angles after a flip, so hatches inside mirrored INSERTs swept the wrong
+    // way and covered the complementary region.
+    #[test]
+    fn test_mirror_hatch_arc_edge_stays_continuous() {
+        use crate::entities::hatch::{BoundaryEdge, BoundaryPath, CircularArcEdge, LineEdge};
+        use crate::types::Vector2;
+
+        // Path: line from (2,0)→... then a CCW half-circle r=1 centered at
+        // (1,0) from angle 0 to π (i.e. (2,0) → (0,0)), then line back.
+        let mut path = BoundaryPath::new();
+        path.edges.push(BoundaryEdge::Line(LineEdge {
+            start: Vector2::new(0.0, -1.0),
+            end: Vector2::new(2.0, 0.0),
+        }));
+        path.edges.push(BoundaryEdge::CircularArc(CircularArcEdge {
+            center: Vector2::new(1.0, 0.0),
+            radius: 1.0,
+            start_angle: 0.0,
+            end_angle: std::f64::consts::PI,
+            counter_clockwise: true,
+        }));
+        path.edges.push(BoundaryEdge::Line(LineEdge {
+            start: Vector2::new(0.0, 0.0),
+            end: Vector2::new(0.0, -1.0),
+        }));
+        let mut hatch = Hatch::new();
+        hatch.paths.push(path);
+
+        // Mirror across the Y axis (x → -x): det < 0, handedness flips.
+        let t = Transform::from_scaling(Vector3::new(-1.0, 1.0, 1.0));
+        transform_hatch(&mut hatch, &t);
+
+        let edges = &hatch.paths[0].edges;
+        let (l1, arc, l2) = match (&edges[0], &edges[1], &edges[2]) {
+            (BoundaryEdge::Line(a), BoundaryEdge::CircularArc(b), BoundaryEdge::Line(c)) => {
+                (a, b, c)
+            }
+            _ => panic!("edge kinds changed"),
+        };
+        // Stored-angle convention: true point of a CW edge is at -θ.
+        let pt = |theta: f64, ccw: bool| {
+            let a = if ccw { theta } else { -theta };
+            (arc.center.x + arc.radius * a.cos(), arc.center.y + arc.radius * a.sin())
+        };
+        let (sx, sy) = pt(arc.start_angle, arc.counter_clockwise);
+        let (ex, ey) = pt(arc.end_angle, arc.counter_clockwise);
+        assert!(!arc.counter_clockwise, "mirror must flip the direction flag");
+        assert!(
+            (sx - l1.end.x).abs() < 1e-9 && (sy - l1.end.y).abs() < 1e-9,
+            "arc start {:?} must meet previous line end {:?}",
+            (sx, sy),
+            (l1.end.x, l1.end.y)
+        );
+        assert!(
+            (ex - l2.start.x).abs() < 1e-9 && (ey - l2.start.y).abs() < 1e-9,
+            "arc end {:?} must meet next line start {:?}",
+            (ex, ey),
+            (l2.start.x, l2.start.y)
+        );
+        // Midpoint sanity: the half-circle bulges DOWN after a y-axis mirror?
+        // Original bulges up (+y); x-mirror keeps +y bulge at mirrored x.
+        let mid_a = {
+            let s = if arc.counter_clockwise { arc.start_angle } else { -arc.start_angle };
+            let e = if arc.counter_clockwise { arc.end_angle } else { -arc.end_angle };
+            let mut sweep = e - s;
+            if arc.counter_clockwise && sweep <= 0.0 { sweep += std::f64::consts::TAU; }
+            if !arc.counter_clockwise && sweep >= 0.0 { sweep -= std::f64::consts::TAU; }
+            s + sweep / 2.0
+        };
+        let (mx, my) = (arc.center.x + arc.radius * mid_a.cos(), arc.center.y + arc.radius * mid_a.sin());
+        assert!(
+            (mx - (-1.0)).abs() < 1e-9 && (my - 1.0).abs() < 1e-9,
+            "arc midpoint {:?} must be the mirror of (1,1) → (-1,1)",
+            (mx, my)
+        );
     }
 }

--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -2390,6 +2390,53 @@ impl DwgDocumentBuilder {
                         crate::objects::ObjectType::GeoData(obj),
                     );
                 },
+                OBJ_BLOCKVISIBILITYPARAMETER => {
+                    // Parse the visibility states into the side map, then still
+                    // store the object verbatim as Unknown so DWG round-trip is
+                    // byte-exact (no typed writer needed).
+                    let mut param = objects::read_block_visibility_parameter(&mut reader);
+                    param.handle = Handle::from(handle);
+                    param.owner = owner_handle;
+                    document
+                        .block_visibility_params
+                        .insert(Handle::from(handle), param);
+
+                    let type_name = format!("DWG_OBJ_{}", type_code);
+                    let raw_handle_bits = reader.get_handle_bits();
+                    let raw_data = reader.raw_merged_data();
+                    document.objects.insert(
+                        Handle::from(handle),
+                        crate::objects::ObjectType::Unknown {
+                            type_name,
+                            handle: Handle::from(handle),
+                            owner: owner_handle,
+                            raw_dxf_codes: None,
+                            raw_dwg_data: Some(raw_data),
+                            raw_dwg_handle_bits: raw_handle_bits,
+                        },
+                    );
+                }
+                OBJ_BLOCKREPRESENTATIONDATA => {
+                    let block = objects::read_block_representation_data(&mut reader);
+                    document
+                        .block_representations
+                        .insert(Handle::from(handle), block);
+
+                    let type_name = format!("DWG_OBJ_{}", type_code);
+                    let raw_handle_bits = reader.get_handle_bits();
+                    let raw_data = reader.raw_merged_data();
+                    document.objects.insert(
+                        Handle::from(handle),
+                        crate::objects::ObjectType::Unknown {
+                            type_name,
+                            handle: Handle::from(handle),
+                            owner: owner_handle,
+                            raw_dxf_codes: None,
+                            raw_dwg_data: Some(raw_data),
+                            raw_dwg_handle_bits: raw_handle_bits,
+                        },
+                    );
+                }
                 _ => {
                     // Preserve unrecognised non-entity objects verbatim so
                     // they survive roundtrip without losing their handles.

--- a/src/io/dwg/dwg_reader.rs
+++ b/src/io/dwg/dwg_reader.rs
@@ -172,6 +172,18 @@ impl DwgReadOptions {
     }
 }
 
+/// Decode a section name from a fixed 64-byte, null-terminated field.
+///
+/// The name ends at the first null byte. Some writers leave non-zero garbage
+/// in the bytes *after* the terminator instead of zero-padding the field, so
+/// trimming trailing nulls is not enough — it would keep the embedded null and
+/// the junk that follows (e.g. `"AcDb:Handles\0t…"`), and the name would then
+/// fail to match when looking the section up.
+fn section_name_from_field(name_buf: &[u8; 64]) -> String {
+    let end = name_buf.iter().position(|&b| b == 0).unwrap_or(name_buf.len());
+    String::from_utf8_lossy(&name_buf[..end]).into_owned()
+}
+
 /// DWG file reader with CRC-64 extraction support.
 ///
 /// Reads DWG binary files and provides access to all internal
@@ -768,12 +780,14 @@ impl<R: Read + Seek> DwgReader<R> {
             let _section_id = cursor.read_i32::<LittleEndian>()?;
             let encrypted = cursor.read_i32::<LittleEndian>()?;
 
-            // Section name (64 bytes, zero-padded)
+            // Section name (64-byte field, null-terminated). Some writers leave
+            // non-zero garbage in the bytes *after* the terminator instead of
+            // zero-padding, so cut at the first null rather than trimming
+            // trailing nulls — otherwise the embedded null plus trailing junk
+            // survives and the name fails to match (e.g. "AcDb:Handles\0t…").
             let mut name_buf = [0u8; 64];
             cursor.read_exact(&mut name_buf)?;
-            let name = String::from_utf8_lossy(&name_buf)
-                .trim_end_matches('\0')
-                .to_string();
+            let name = section_name_from_field(&name_buf);
 
             // Per-page entries: pageNumber(4), compressedSize(4), offset(8)
             let mut pages = Vec::new();
@@ -1614,5 +1628,37 @@ impl std::fmt::Display for CrcExtractionReport {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod section_name_tests {
+    use super::section_name_from_field;
+
+    fn field(prefix: &[u8]) -> [u8; 64] {
+        let mut b = [0u8; 64];
+        b[..prefix.len()].copy_from_slice(prefix);
+        b
+    }
+
+    #[test]
+    fn clean_zero_padded_name() {
+        assert_eq!(section_name_from_field(&field(b"AcDb:Handles")), "AcDb:Handles");
+    }
+
+    #[test]
+    fn stops_at_first_null_ignoring_trailing_garbage() {
+        // Terminator at index 12, then non-zero junk — the real-world case that
+        // broke `trim_end_matches('\0')`.
+        let mut b = field(b"AcDb:Handles");
+        b[13] = b't';
+        b[14] = 0x01;
+        b[20] = b'X';
+        assert_eq!(section_name_from_field(&b), "AcDb:Handles");
+    }
+
+    #[test]
+    fn empty_when_first_byte_null() {
+        assert_eq!(section_name_from_field(&[0u8; 64]), "");
     }
 }

--- a/src/io/dwg/dwg_reader.rs
+++ b/src/io/dwg/dwg_reader.rs
@@ -172,6 +172,78 @@ impl DwgReadOptions {
     }
 }
 
+/// Find the first occurrence of `needle` in `haystack` at or after `from`.
+fn find_subsequence(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    (from..=haystack.len() - needle.len()).find(|&i| &haystack[i..i + needle.len()] == needle)
+}
+
+/// Extract every SAB (ACIS/ASM binary) blob from a decompressed AcDs section.
+///
+/// Each blob runs from its header magic — `"ACIS BinaryFile"` (classic ACIS) or
+/// `"ASM BinaryFile"` (Autodesk ShapeManager, AutoCAD 2013+) — through the
+/// `End-of-ASM-data` terminator. Blobs are returned in the order they appear,
+/// which matches the order the modeler entities were written.
+fn extract_acds_sab_blobs(buf: &[u8]) -> Vec<Vec<u8>> {
+    // 0E 03 "End" 0E 02 "of" 0E 03 "ASM" 0D 04 "data"
+    const END_MARKER: &[u8] = b"\x0E\x03End\x0E\x02of\x0E\x03ASM\x0D\x04data";
+    const ACIS_MAGIC: &[u8] = b"ACIS BinaryFile";
+    const ASM_MAGIC: &[u8] = b"ASM BinaryFile";
+
+    let mut blobs = Vec::new();
+    let mut pos = 0usize;
+    while pos < buf.len() {
+        let acis = find_subsequence(buf, ACIS_MAGIC, pos);
+        let asm = find_subsequence(buf, ASM_MAGIC, pos);
+        let start = match (acis, asm) {
+            (Some(a), Some(b)) => a.min(b),
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            (None, None) => break,
+        };
+        match find_subsequence(buf, END_MARKER, start) {
+            Some(end) => {
+                let stop = end + END_MARKER.len();
+                blobs.push(buf[start..stop].to_vec());
+                pos = stop;
+            }
+            None => break,
+        }
+    }
+    blobs
+}
+
+/// Attach extracted AcDs SAB blobs, in order, to the document's modeler
+/// (3DSOLID / REGION / BODY) entities. Returns the number attached.
+fn attach_acds_sab_blobs(document: &mut crate::document::CadDocument, blobs: Vec<Vec<u8>>) -> usize {
+    use crate::entities::solid3d::AcisVersion;
+    use crate::entities::EntityType;
+
+    let mut it = blobs.into_iter();
+    let mut attached = 0usize;
+    for entity in document.entities_mut() {
+        let acis = match entity {
+            EntityType::Solid3D(s) => &mut s.acis_data,
+            EntityType::Region(r) => &mut r.acis_data,
+            EntityType::Body(b) => &mut b.acis_data,
+            _ => continue,
+        };
+        match it.next() {
+            Some(blob) => {
+                acis.sab_data = blob;
+                acis.sat_data = String::new();
+                acis.is_binary = true;
+                acis.version = AcisVersion::Version2;
+                attached += 1;
+            }
+            None => break,
+        }
+    }
+    attached
+}
+
 /// Decode a section name from a fixed 64-byte, null-terminated field.
 ///
 /// The name ends at the first null byte. Some writers leave non-zero garbage
@@ -346,6 +418,22 @@ impl<R: Read + Seek> DwgReader<R> {
                         format!("Failed to init object reader: {}", e),
                     ),
                 }
+            }
+        }
+
+        // 6. R2013+ (AC1027+): 3DSOLID / REGION / BODY ACIS geometry is not
+        //    stored inline — it lives as SAB blobs in the AcDs (Autodesk Data
+        //    Store) section. Extract those blobs and attach them, in document
+        //    order, to the modeler-geometry entities that arrived with only a
+        //    stub. Files without an AcDs section keep their inline data.
+        if let Ok(acds_buf) = self.get_section_buffer("AcDb:AcDsPrototype_1b", &info) {
+            let blobs = extract_acds_sab_blobs(&acds_buf);
+            if !blobs.is_empty() {
+                let attached = attach_acds_sab_blobs(&mut document, blobs);
+                self.notifications.notify(
+                    NotificationType::Warning,
+                    format!("AcDs: attached {} SAB blob(s) to modeler entities", attached),
+                );
             }
         }
 

--- a/src/io/dwg/dwg_stream_readers/object_reader/common.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/common.rs
@@ -123,6 +123,12 @@ pub const OBJ_TABLESTYLE: i16 = 0x6A;       // 106
 // GEODATA has no fixed DWG type code (it is always class-based); 0x83 is a free
 // internal sentinel used by the class-number map + builder dispatch.
 pub const OBJ_GEODATA: i16 = 0x83;          // 131
+// AcDbBlockVisibilityParameter is always class-based; 0x84 is a free internal
+// sentinel for the class-number map + builder dispatch.
+pub const OBJ_BLOCKVISIBILITYPARAMETER: i16 = 0x84; // 132
+// AcDbBlockRepresentationData — links an anonymous evaluated block back to its
+// dynamic block definition. 0x85 is a free internal sentinel.
+pub const OBJ_BLOCKREPRESENTATIONDATA: i16 = 0x85; // 133
 
 /// Returns true if the type code is a graphical entity (not a table / object).
 pub fn is_entity_type(type_code: i16) -> bool {
@@ -171,6 +177,10 @@ pub fn dxf_name_to_type_code(dxf_name: &str) -> Option<i16> {
         "TABLECONTENT" => Some(OBJ_TABLECONTENT),
         "TABLESTYLE" => Some(OBJ_TABLESTYLE),
         "GEODATA" | "ACDBGEODATA" => Some(OBJ_GEODATA),
+        "BLOCKVISIBILITYPARAMETER" => Some(OBJ_BLOCKVISIBILITYPARAMETER),
+        "ACDB_BLOCKREPRESENTATION_DATA" | "BLOCKREPRESENTATION" => {
+            Some(OBJ_BLOCKREPRESENTATIONDATA)
+        }
         _ => None,
     }
 }

--- a/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
@@ -305,6 +305,116 @@ pub fn read_dictionary_variable(reader: &mut DwgMergedReader) -> DictionaryVaria
     DictionaryVariableData { schema_number, value }
 }
 
+/// Read an AcDbBlockVisibilityParameter object body (after the common
+/// non-entity header). Follows the class chain
+/// AcDbEvalExpr → AcDbBlockElement → AcDbBlockParameter →
+/// AcDbBlock1PtParameter → AcDbBlockVisibilityParameter.
+///
+/// Numeric fields come from the main stream, text from the text stream, and
+/// handles from the handle stream — the merged reader keeps the three cursors
+/// independent, so reads in spec order self-align across the substreams.
+///
+/// `handle`/`owner` are filled by the caller. Returns the parsed parameter.
+pub fn read_block_visibility_parameter(
+    reader: &mut DwgMergedReader,
+) -> crate::objects::BlockVisibilityParameter {
+    use crate::objects::{BlockVisibilityParameter, BlockVisibilityState};
+    let mut p = BlockVisibilityParameter::default();
+
+    // ── AcDbEvalExpr ──
+    let _parent_id = reader.read_bit_long(); // BLd parentid
+    let _major = reader.read_bit_long(); // BL (98)
+    let _minor = reader.read_bit_long(); // BL (99)
+    let value_code = reader.read_bit_short(); // BSd value_code (70)
+    match value_code {
+        40 => {
+            let _ = reader.read_bit_double();
+        }
+        10 | 11 => {
+            let _ = reader.read_2raw_double();
+        }
+        1 => {
+            let _ = reader.read_variable_text();
+        }
+        90 => {
+            let _ = reader.read_bit_long();
+        }
+        91 => {
+            let _ = reader.read_handle();
+        }
+        70 => {
+            let _ = reader.read_bit_short();
+        }
+        _ => {}
+    }
+    let _node_id = reader.read_bit_long(); // BL nodeid
+
+    // ── AcDbBlockElement ──
+    let _elem_name = reader.read_variable_text(); // T name (300)
+    let _be_major = reader.read_bit_long(); // BL (98)
+    let _be_minor = reader.read_bit_long(); // BL (99)
+    let _eed1071 = reader.read_bit_long(); // BL (1071)
+
+    // ── AcDbBlockParameter ──
+    let _show_properties = reader.read_bit(); // B (280)
+    let _chain_actions = reader.read_bit(); // B (281)
+
+    // ── AcDbBlock1PtParameter ──
+    p.def_point = reader.read_3bit_double(); // 3BD def_pt (1010)
+    // Two PropInfo blocks: each is a BL connection count + (BL code, T name) pairs.
+    for _ in 0..2 {
+        let n = safe_count(reader.read_bit_long());
+        for _ in 0..n {
+            let _code = reader.read_bit_long();
+            let _name = reader.read_variable_text();
+        }
+    }
+    let _num_propinfos = reader.read_bit_long(); // BL num_propinfos
+
+    // ── AcDbBlockVisibilityParameter ──
+    let _is_initialized = reader.read_bit(); // B (281)
+    p.name = reader.read_variable_text(); // T blockvisi_name (301)
+    p.description = reader.read_variable_text(); // T blockvisi_desc (302)
+    let _unknown_bool = reader.read_bit(); // B (91)
+
+    let num_blocks = safe_count(reader.read_bit_long()); // BL num_blocks (93)
+    for _ in 0..num_blocks {
+        p.all_blocks.push(crate::types::Handle::from(reader.read_handle()));
+    }
+
+    let num_states = safe_count(reader.read_bit_long()); // BL num_states (92)
+    for _ in 0..num_states {
+        let mut st = BlockVisibilityState {
+            name: reader.read_variable_text(), // T state name (303)
+            ..Default::default()
+        };
+        let nb = safe_count(reader.read_bit_long()); // BL (94)
+        for _ in 0..nb {
+            st.visible_blocks
+                .push(crate::types::Handle::from(reader.read_handle()));
+        }
+        let np = safe_count(reader.read_bit_long()); // BL (95)
+        for _ in 0..np {
+            st.visible_params
+                .push(crate::types::Handle::from(reader.read_handle()));
+        }
+        p.states.push(st);
+    }
+
+    p
+}
+
+/// Read an AcDbBlockRepresentationData object body (after the common
+/// non-entity header) and return the handle of the dynamic block definition
+/// it represents (group code 340, a hard pointer). This is the link from an
+/// anonymous evaluated block back to its dynamic block definition.
+///
+/// Layout: BS flag (70), then the block handle from the handle stream.
+pub fn read_block_representation_data(reader: &mut DwgMergedReader) -> crate::types::Handle {
+    let _flag = reader.read_bit_short(); // BS (70)
+    crate::types::Handle::from(reader.read_handle()) // H block (3, 340)
+}
+
 /// Read the PlotSettings data portion (shared by Layout and standalone PlotSettings).
 pub fn read_plot_settings_data(reader: &mut DwgMergedReader, version: DwgVersion) -> PlotSettingsData {
     let page_name = reader.read_variable_text();

--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -300,6 +300,8 @@ impl<'a> SectionReader<'a> {
                 "$TEXTSTYLE" => { if let Some(p) = self.reader.read_pair()? { hdr.current_text_style_name = p.value_string.clone(); } }
                 "$DIMSTYLE" => { if let Some(p) = self.reader.read_pair()? { hdr.current_dimstyle_name = p.value_string.clone(); } }
                 "$CMLSTYLE" => { if let Some(p) = self.reader.read_pair()? { hdr.multiline_style = p.value_string.clone(); } }
+                "$CTABLESTYLE" => { if let Some(p) = self.reader.read_pair()? { hdr.current_table_style_name = p.value_string.clone(); } }
+                "$CMLEADERSTYLE" => { if let Some(p) = self.reader.read_pair()? { hdr.current_mleader_style_name = p.value_string.clone(); } }
 
                 // ── Extents / Limits (multi-value XYZ / XY) ──
                 "$INSBASE" => { self.read_header_point3(&mut hdr.model_space_insertion_base)?; }

--- a/src/io/dxf/writer/section_writer.rs
+++ b/src/io/dxf/writer/section_writer.rs
@@ -166,7 +166,8 @@ impl<'a, W: DxfStreamWriter> SectionWriter<'a, W> {
         self.write_header_variable("$TRACEWID", |w| w.write_double(40, hdr.trace_width))?;
         self.write_header_variable("$TEXTSTYLE", |w| w.write_string(7, &hdr.current_text_style_name))?;
         self.write_header_variable("$CMLSTYLE", |w| w.write_string(2, &hdr.multiline_style))?;
-        self.write_header_variable("$CTABLESTYLE", |w| w.write_string(2, "Standard"))?;
+        self.write_header_variable("$CTABLESTYLE", |w| w.write_string(2, &hdr.current_table_style_name))?;
+        self.write_header_variable("$CMLEADERSTYLE", |w| w.write_string(2, &hdr.current_mleader_style_name))?;
         self.write_header_variable("$CLAYER", |w| w.write_string(8, &hdr.current_layer_name))?;
         self.write_header_variable("$CELTYPE", |w| w.write_string(6, &hdr.current_linetype_name))?;
         self.write_header_variable("$CECOLOR", |w| w.write_i16(62, hdr.current_entity_color.approximate_index()))?;

--- a/src/objects/block_visibility.rs
+++ b/src/objects/block_visibility.rs
@@ -1,0 +1,47 @@
+//! Dynamic-block visibility parameter (AcDbBlockVisibilityParameter).
+//!
+//! A dynamic block with a visibility parameter keeps the geometry for every
+//! visibility state in a single (anonymous) block definition. The parameter
+//! object lists, per state, which member entities are visible. The currently
+//! shown state is baked into the anonymous block by marking the other states'
+//! entities invisible, so a plain reader still renders the right subset — but
+//! switching states needs the full per-state membership recorded here.
+//!
+//! These objects are still preserved verbatim as `ObjectType::Unknown` for
+//! DWG round-trip; this is a parsed *side* view keyed by the parameter handle.
+
+use crate::types::{Handle, Vector3};
+
+/// One visibility state: a named choice (e.g. "120") and the member entities
+/// that are visible while it is active.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BlockVisibilityState {
+    /// State name as shown in the lookup list (e.g. "80", "120", "600").
+    pub name: String,
+    /// Handles of member entities visible while this state is active.
+    pub visible_blocks: Vec<Handle>,
+    /// Handles of member parameters active while this state is active.
+    pub visible_params: Vec<Handle>,
+}
+
+/// Parsed AcDbBlockVisibilityParameter: the visibility grip location, the full
+/// member list, and every selectable state with its visible-entity set.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BlockVisibilityParameter {
+    /// Handle of the parameter object itself.
+    pub handle: Handle,
+    /// Owner handle (the block record's extension dictionary chain).
+    pub owner: Handle,
+    /// Parameter display name (group code 301).
+    pub name: String,
+    /// Parameter description (group code 302).
+    pub description: String,
+    /// Grip / definition point in block-definition coordinates.
+    pub def_point: Vector3,
+    /// All member entity handles the parameter governs (the union of states).
+    pub all_blocks: Vec<Handle>,
+    /// Selectable visibility states, in list order.
+    pub states: Vec<BlockVisibilityState>,
+}

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -3,6 +3,7 @@
 //! Objects are non-graphical elements in a DXF file, such as dictionaries,
 //! layouts, groups, and other organizational structures.
 
+mod block_visibility;
 mod dictionary_variable;
 mod group;
 mod image_definition;
@@ -15,6 +16,7 @@ mod table_style;
 mod xrecord;
 mod stub_objects;
 
+pub use block_visibility::{BlockVisibilityParameter, BlockVisibilityState};
 pub use dictionary_variable::DictionaryVariable;
 pub use group::Group;
 pub use image_definition::{ImageDefinition, ImageDefinitionReactor, ResolutionUnit};

--- a/tests/current_style_header.rs
+++ b/tests/current_style_header.rs
@@ -1,0 +1,27 @@
+//! DXF round-trip of the current table / multileader style header variables
+//! ($CTABLESTYLE / $CMLEADERSTYLE), plus the existing text/dim/mline ones.
+
+use acadrust::{CadDocument, DxfReader, DxfWriter};
+
+#[test]
+fn dxf_roundtrips_current_style_header_vars() {
+    let mut doc = CadDocument::new();
+    doc.header.current_text_style_name = "MyText".to_string();
+    doc.header.current_dimstyle_name = "MyDim".to_string();
+    doc.header.multiline_style = "MyMline".to_string();
+    doc.header.current_table_style_name = "MyTable".to_string();
+    doc.header.current_mleader_style_name = "MyLeader".to_string();
+
+    let path = std::env::temp_dir().join("acadrust_current_style_roundtrip.dxf");
+    DxfWriter::new(&doc)
+        .write_to_file(&path)
+        .expect("write dxf");
+    let loaded = DxfReader::from_file(&path).expect("open").read().expect("read");
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(loaded.header.current_text_style_name, "MyText");
+    assert_eq!(loaded.header.current_dimstyle_name, "MyDim");
+    assert_eq!(loaded.header.multiline_style, "MyMline");
+    assert_eq!(loaded.header.current_table_style_name, "MyTable");
+    assert_eq!(loaded.header.current_mleader_style_name, "MyLeader");
+}


### PR DESCRIPTION
Phase 2 of #24 — a batch of independent transform/IO fixes plus two DWG reader features. Grouped by area:

## Transform / explode / mirror fidelity
- **Hatch CW boundary arcs** (`ddd6888`): store convention-correct (mirrored) angles for clockwise boundary-arc edges. Work in true-angle space (un-mirror → transform → re-mirror) so hatches inside mirrored INSERTs and after EXPLODE sweep the right way instead of covering the complementary region.
- **Wrap-encoded arc sweeps** (`64efaf8`): transform only the start angle and carry the stored sweep over unchanged. Arcs whose `end` is encoded above 2π (crossing the 0 axis) no longer collapse to their near-full-circle complement when a hatch passes through an INSERT or is exploded.
- **Reflecting transforms** (`40c06f4`): negate lwpolyline / polyline2d bulges under any reflecting transform (negative upper-3×3 determinant); the `mirror_*` wrappers now delegate instead of double-negating, and the redundant angle post-pass in `mirror_hatch` is dropped.
- **Ellipse WCS** (`569bd4d`): ELLIPSE center/major-axis are WCS per the DXF spec, so the insert-explode paths store them directly instead of round-tripping through the normal's OCS — mirrored-explode normals `(0,0,-1)` no longer misplace the ellipse in other CAD apps. Z-up case is bit-identical.

## DWG reader
- **AC18 section names** (`426a353`): cut the 64-byte section-name field at the first null. Writers that leave non-zero garbage after the terminator previously broke `get_section_buffer` lookup, which silently dropped the entire AcDbObjects section and loaded the document with zero entities.
- **Dynamic-block visibility** (`33b43e0`): parse AcDbBlockVisibilityParameter + AcDbBlockRepresentationData (LibreDWG field layout for the AcDbEvalExpr → BlockElement → BlockParameter → Block1PtParameter chain). Exposes visibility states with their per-state member handles plus `block_visibility_param_for_def()` / `dynamic_visibility_for_insert()`. Objects stay verbatim as `ObjectType::Unknown` for byte-exact round-trip; the parsed data is a side view.

## DXF header
- **Current table / multileader style** (`2f3ff79`): read/write CTABLESTYLE / CMLEADERSTYLE header vars (previously `$CTABLESTYLE` was hard-coded to `"Standard"`).

Each commit carries regression tests and/or real-file verification in its message.
