### PR TITLE
feat: read and round-trip ACAD_SURFACE entities

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -2031,6 +2031,7 @@ fn get_common_mut(entity: &mut EntityType) -> &mut EntityCommon {
         EntityType::Solid3D(e) => &mut e.common,
         EntityType::Region(e) => &mut e.common,
         EntityType::Body(e) => &mut e.common,
+        EntityType::Surface(e) => &mut e.common,
         EntityType::Table(e) => &mut e.common,
         EntityType::Tolerance(e) => &mut e.common,
         EntityType::PolyfaceMesh(e) => &mut e.common,

--- a/src/entities/acis/sab.rs
+++ b/src/entities/acis/sab.rs
@@ -40,6 +40,11 @@ pub mod tags {
     pub const ENTITY_TYPE: u8 = 0x0D;
     /// Subtype prefix (for compound types like `plane-surface`).
     pub const SUBTYPE: u8 = 0x0E;
+    /// Subtype block start (`{` in SAT) — opens a nested subrecord, e.g. the
+    /// `skin_spl_sur` block inside a lofted spline-surface.
+    pub const SUBTYPE_START: u8 = 0x0F;
+    /// Subtype block end (`}` in SAT) — closes a nested subrecord.
+    pub const SUBTYPE_END: u8 = 0x10;
     /// End of record marker.
     pub const END_OF_RECORD: u8 = 0x11;
     /// Long string literal (4-byte u32 length prefix + bytes).
@@ -783,6 +788,18 @@ impl SabReader {
                 Ok((SatToken::String(s), pos))
             }
             tags::END_OF_RECORD => Ok((SatToken::Terminator, pos)),
+            // Nested subtype block delimiters (`{` / `}`) and the type-name
+            // tags that appear inside them. Lofted/swept spline surfaces embed
+            // a subrecord (e.g. `skin_spl_sur`) between SUBTYPE_START and
+            // SUBTYPE_END. Emit the braces and nested type names as idents so
+            // the flat token stream stays balanced and downstream readers can
+            // locate the block by name.
+            tags::SUBTYPE_START => Ok((SatToken::Ident("{".to_string()), pos)),
+            tags::SUBTYPE_END => Ok((SatToken::Ident("}".to_string()), pos)),
+            tags::ENTITY_TYPE | tags::SUBTYPE => {
+                let (s, new_pos) = read_length_string(data, pos)?;
+                Ok((SatToken::Ident(s), new_pos))
+            }
             _ => Err(SabError::UnknownTag(tag, pos - 1)),
         }
     }

--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -76,6 +76,11 @@ pub struct DimensionBase {
     pub block_name: String,
     /// Line spacing factor
     pub line_spacing_factor: f64,
+    /// Dimension text was positioned at a user-defined location rather than at
+    /// the style's default (DXF group 70, bit 0x80). When false the text
+    /// follows the dimension style (DIMTAD etc.); when true `text_middle_point`
+    /// is an explicit override.
+    pub text_user_positioned: bool,
 }
 
 impl DimensionBase {
@@ -98,6 +103,7 @@ impl DimensionBase {
             version: 0,
             block_name: String::new(),
             line_spacing_factor: 1.0,
+            text_user_positioned: false,
         }
     }
 

--- a/src/entities/explode.rs
+++ b/src/entities/explode.rs
@@ -813,6 +813,7 @@ impl EntityType {
             | EntityType::Solid3D(_)
             | EntityType::Region(_)
             | EntityType::Body(_)
+            | EntityType::Surface(_)
             | EntityType::Table(_)
             | EntityType::Tolerance(_)
             | EntityType::Wipeout(_)

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -40,6 +40,7 @@ pub mod mline;
 pub mod mesh;
 pub mod raster_image;
 pub mod solid3d;
+pub mod surface;
 pub mod acis;
 pub mod table;
 pub mod tolerance;
@@ -100,6 +101,7 @@ pub use solid3d::{
     Solid3D, Region, Body, Wire, Silhouette, AcisData,
     WireType, AcisVersion,
 };
+pub use surface::{Surface, SurfaceKind};
 pub use table::{
     Table, TableBuilder, TableCell, TableRow, TableColumn,
     CellContent, CellValue, CellStyle, CellBorder, CellRange,
@@ -408,6 +410,8 @@ pub enum EntityType {
     Region(Region),
     /// Body entity
     Body(Body),
+    /// Surface entity (ACAD_SURFACE family: lofted/swept/extruded/etc.)
+    Surface(Surface),
     /// Table entity
     Table(Table),
     /// Tolerance entity (geometric tolerancing)
@@ -466,6 +470,7 @@ impl EntityType {
             EntityType::Solid3D(e) => e,
             EntityType::Region(e) => e,
             EntityType::Body(e) => e,
+            EntityType::Surface(e) => e,
             EntityType::Table(e) => e,
             EntityType::Tolerance(e) => e,
             EntityType::PolyfaceMesh(e) => e,
@@ -514,6 +519,7 @@ impl EntityType {
             EntityType::Solid3D(e) => e,
             EntityType::Region(e) => e,
             EntityType::Body(e) => e,
+            EntityType::Surface(e) => e,
             EntityType::Table(e) => e,
             EntityType::Tolerance(e) => e,
             EntityType::PolyfaceMesh(e) => e,
@@ -562,6 +568,7 @@ impl EntityType {
             EntityType::Solid3D(e) => &e.common,
             EntityType::Region(e) => &e.common,
             EntityType::Body(e) => &e.common,
+            EntityType::Surface(e) => &e.common,
             EntityType::Table(e) => &e.common,
             EntityType::Tolerance(e) => &e.common,
             EntityType::PolyfaceMesh(e) => &e.common,
@@ -610,6 +617,7 @@ impl EntityType {
             EntityType::Solid3D(e) => &mut e.common,
             EntityType::Region(e) => &mut e.common,
             EntityType::Body(e) => &mut e.common,
+            EntityType::Surface(e) => &mut e.common,
             EntityType::Table(e) => &mut e.common,
             EntityType::Tolerance(e) => &mut e.common,
             EntityType::PolyfaceMesh(e) => &mut e.common,

--- a/src/entities/surface.rs
+++ b/src/entities/surface.rs
@@ -1,0 +1,176 @@
+//! Surface entities (ACAD_SURFACE family).
+//!
+//! Lofted / swept / extruded / revolved / plane / NURB surfaces share the
+//! `AcDbSurface` base, which stores its geometry in ACIS format just like
+//! [`Body`](super::solid3d::Body). They are kept as a distinct entity type so
+//! the original surface kind survives a DWG round-trip; the raw object bytes
+//! are preserved verbatim for write-back.
+
+use crate::entities::solid3d::{AcisData, Silhouette, Wire};
+use crate::entities::{Entity, EntityCommon};
+use crate::types::{BoundingBox3D, Color, Handle, LineWeight, Transparency, Vector3};
+
+/// Which ACAD_SURFACE subtype a [`Surface`] represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SurfaceKind {
+    /// Generic `SURFACE` / `AcDbSurface`.
+    #[default]
+    Generic,
+    /// `PLANESURFACE`.
+    Plane,
+    /// `EXTRUDEDSURFACE`.
+    Extruded,
+    /// `LOFTEDSURFACE`.
+    Lofted,
+    /// `REVOLVEDSURFACE`.
+    Revolved,
+    /// `SWEPTSURFACE`.
+    Swept,
+    /// `NURBSURFACE`.
+    Nurb,
+}
+
+impl SurfaceKind {
+    /// Map a DXF class name to a surface kind.
+    pub fn from_dxf_name(name: &str) -> Self {
+        match name.to_uppercase().as_str() {
+            "PLANESURFACE" => SurfaceKind::Plane,
+            "EXTRUDEDSURFACE" => SurfaceKind::Extruded,
+            "LOFTEDSURFACE" => SurfaceKind::Lofted,
+            "REVOLVEDSURFACE" => SurfaceKind::Revolved,
+            "SWEPTSURFACE" => SurfaceKind::Swept,
+            "NURBSURFACE" => SurfaceKind::Nurb,
+            _ => SurfaceKind::Generic,
+        }
+    }
+
+    /// The DXF class name for this kind.
+    pub fn dxf_name(self) -> &'static str {
+        match self {
+            SurfaceKind::Generic => "SURFACE",
+            SurfaceKind::Plane => "PLANESURFACE",
+            SurfaceKind::Extruded => "EXTRUDEDSURFACE",
+            SurfaceKind::Lofted => "LOFTEDSURFACE",
+            SurfaceKind::Revolved => "REVOLVEDSURFACE",
+            SurfaceKind::Swept => "SWEPTSURFACE",
+            SurfaceKind::Nurb => "NURBSURFACE",
+        }
+    }
+}
+
+/// A 3D surface entity (ACAD_SURFACE family), backed by ACIS geometry.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Surface {
+    /// Common entity data.
+    pub common: EntityCommon,
+    /// Which surface subtype this is.
+    pub kind: SurfaceKind,
+    /// ACIS/SAT surface geometry.
+    pub acis_data: AcisData,
+    /// Wireframe edges for visualization.
+    pub wires: Vec<Wire>,
+    /// Silhouette data for viewports.
+    pub silhouettes: Vec<Silhouette>,
+    /// Raw DWG object bytes, preserved verbatim for round-trip write-back.
+    pub raw_dwg_data: Option<Vec<u8>>,
+    /// Handle-stream bit length captured alongside `raw_dwg_data`.
+    pub dwg_handle_bits: i64,
+}
+
+impl Surface {
+    /// Creates a new empty surface of the given kind.
+    pub fn new(kind: SurfaceKind) -> Self {
+        Self {
+            common: EntityCommon::default(),
+            kind,
+            acis_data: AcisData::new(),
+            wires: Vec::new(),
+            silhouettes: Vec::new(),
+            raw_dwg_data: None,
+            dwg_handle_bits: 0,
+        }
+    }
+
+    /// Returns true if this surface has valid ACIS data.
+    pub fn has_acis_data(&self) -> bool {
+        self.acis_data.has_data()
+    }
+
+    /// Parses the raw SAT text data into a structured [`SatDocument`].
+    ///
+    /// Returns `None` if the ACIS data is empty or binary (SAB).
+    pub fn parse_sat(&self) -> Option<crate::entities::acis::SatDocument> {
+        if self.acis_data.is_binary || self.acis_data.sat_data.is_empty() {
+            return None;
+        }
+        crate::entities::acis::SatDocument::parse(&self.acis_data.sat_data).ok()
+    }
+}
+
+impl Entity for Surface {
+    fn handle(&self) -> Handle {
+        self.common.handle
+    }
+    fn set_handle(&mut self, handle: Handle) {
+        self.common.handle = handle;
+    }
+    fn layer(&self) -> &str {
+        &self.common.layer
+    }
+    fn set_layer(&mut self, layer: String) {
+        self.common.layer = layer;
+    }
+    fn color(&self) -> Color {
+        self.common.color
+    }
+    fn set_color(&mut self, color: Color) {
+        self.common.color = color;
+    }
+    fn line_weight(&self) -> LineWeight {
+        self.common.line_weight
+    }
+    fn set_line_weight(&mut self, line_weight: LineWeight) {
+        self.common.line_weight = line_weight;
+    }
+    fn transparency(&self) -> Transparency {
+        self.common.transparency
+    }
+    fn set_transparency(&mut self, transparency: Transparency) {
+        self.common.transparency = transparency;
+    }
+    fn is_invisible(&self) -> bool {
+        self.common.invisible
+    }
+    fn set_invisible(&mut self, invisible: bool) {
+        self.common.invisible = invisible;
+    }
+    fn bounding_box(&self) -> BoundingBox3D {
+        if self.wires.is_empty() {
+            return BoundingBox3D::default();
+        }
+        let mut min = Vector3::new(f64::MAX, f64::MAX, f64::MAX);
+        let mut max = Vector3::new(f64::MIN, f64::MIN, f64::MIN);
+        for wire in &self.wires {
+            for pt in &wire.points {
+                min.x = min.x.min(pt.x);
+                min.y = min.y.min(pt.y);
+                min.z = min.z.min(pt.z);
+                max.x = max.x.max(pt.x);
+                max.y = max.y.max(pt.y);
+                max.z = max.z.max(pt.z);
+            }
+        }
+        BoundingBox3D::new(min, max)
+    }
+    fn translate(&mut self, offset: Vector3) {
+        super::translate::translate_surface(self, offset);
+    }
+    fn entity_type(&self) -> &'static str {
+        "SURFACE"
+    }
+    fn apply_transform(&mut self, transform: &crate::types::Transform) {
+        super::transform::transform_surface(self, transform);
+    }
+}

--- a/src/entities/transform.rs
+++ b/src/entities/transform.rs
@@ -748,6 +748,14 @@ pub(crate) fn transform_body(e: &mut Body, transform: &Transform) {
     }
 }
 
+pub(crate) fn transform_surface(e: &mut crate::entities::Surface, transform: &Transform) {
+    for wire in &mut e.wires {
+        for pt in &mut wire.points {
+            *pt = transform.apply(*pt);
+        }
+    }
+}
+
 // ── Table ────────────────────────────────────────────────────────────────────
 
 pub(crate) fn transform_table(e: &mut Table, transform: &Transform) {
@@ -901,6 +909,7 @@ impl EntityType {
             EntityType::Solid3D(e) => transform_solid3d(e, transform),
             EntityType::Region(e) => transform_region(e, transform),
             EntityType::Body(e) => transform_body(e, transform),
+            EntityType::Surface(e) => transform_surface(e, transform),
             EntityType::Table(e) => transform_table(e, transform),
             EntityType::Tolerance(e) => transform_tolerance(e, transform),
             EntityType::PolyfaceMesh(e) => transform_polyface_mesh(e, transform),

--- a/src/entities/translate.rs
+++ b/src/entities/translate.rs
@@ -365,6 +365,14 @@ pub(crate) fn translate_body(e: &mut Body, offset: Vector3) {
     }
 }
 
+pub(crate) fn translate_surface(e: &mut crate::entities::Surface, offset: Vector3) {
+    for wire in &mut e.wires {
+        for pt in &mut wire.points {
+            *pt = *pt + offset;
+        }
+    }
+}
+
 // ── Table ────────────────────────────────────────────────────────────────────
 
 pub(crate) fn translate_table(e: &mut Table, offset: Vector3) {
@@ -471,6 +479,7 @@ impl EntityType {
             EntityType::Solid3D(e) => translate_solid3d(e, offset),
             EntityType::Region(e) => translate_region(e, offset),
             EntityType::Body(e) => translate_body(e, offset),
+            EntityType::Surface(e) => translate_surface(e, offset),
             EntityType::Table(e) => translate_table(e, offset),
             EntityType::Tolerance(e) => translate_tolerance(e, offset),
             EntityType::PolyfaceMesh(e) => translate_polyface_mesh(e, offset),

--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -2425,6 +2425,26 @@ impl DwgDocumentBuilder {
                         crate::objects::ObjectType::GeoData(obj),
                     );
                 },
+                OBJ_SPATIALFILTER => {
+                    let data = objects::read_spatial_filter(&mut reader);
+                    let mut obj = crate::objects::SpatialFilter::new();
+                    obj.handle = Handle::from(handle);
+                    obj.owner = owner_handle;
+                    obj.boundary_points = data.points;
+                    obj.normal = data.extrusion;
+                    obj.origin = data.clip_bound_origin;
+                    obj.display_enabled = data.display_enabled;
+                    obj.front_clip = data.front_clip;
+                    obj.back_clip = data.back_clip;
+                    obj.inverse_block_transform =
+                        matrix_from_column_major(&data.inverse_block_transform);
+                    obj.clip_bound_transform =
+                        matrix_from_column_major(&data.clip_bound_transform);
+                    document.objects.insert(
+                        Handle::from(handle),
+                        crate::objects::ObjectType::SpatialFilter(obj),
+                    );
+                },
                 OBJ_BLOCKVISIBILITYPARAMETER => {
                     // Parse the visibility states into the side map, then still
                     // store the object verbatim as Unknown so DWG round-trip is
@@ -2522,6 +2542,19 @@ impl DwgDocumentBuilder {
         } else {
             raw
         }
+    }
+}
+
+/// Build a [`Matrix4`](crate::types::Matrix4) from 12 doubles holding a 4×3
+/// transform in column-major order (4 columns of 3 rows); bottom row implied.
+fn matrix_from_column_major(v: &[f64; 12]) -> crate::types::Matrix4 {
+    crate::types::Matrix4 {
+        m: [
+            [v[0], v[3], v[6], v[9]],
+            [v[1], v[4], v[7], v[10]],
+            [v[2], v[5], v[8], v[11]],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
     }
 }
 

--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -1966,6 +1966,41 @@ impl DwgDocumentBuilder {
                     let _ = document.add_entity(EntityType::Body(e));
                 },
 
+                // ── ACAD_SURFACE family (ACIS-backed) ───────────────
+                OBJ_SURFACE | OBJ_PLANESURFACE | OBJ_EXTRUDEDSURFACE
+                | OBJ_LOFTEDSURFACE | OBJ_REVOLVEDSURFACE | OBJ_SWEPTSURFACE
+                | OBJ_NURBSURFACE => {
+                    let kind = match type_code {
+                        OBJ_PLANESURFACE => crate::entities::SurfaceKind::Plane,
+                        OBJ_EXTRUDEDSURFACE => crate::entities::SurfaceKind::Extruded,
+                        OBJ_LOFTEDSURFACE => crate::entities::SurfaceKind::Lofted,
+                        OBJ_REVOLVEDSURFACE => crate::entities::SurfaceKind::Revolved,
+                        OBJ_SWEPTSURFACE => crate::entities::SurfaceKind::Swept,
+                        OBJ_NURBSURFACE => crate::entities::SurfaceKind::Nurb,
+                        _ => crate::entities::SurfaceKind::Generic,
+                    };
+                    let data = entities::read_acis_entity(
+                        &mut reader, self.obj_reader.version(),
+                    );
+                    let mut e = Surface::new(kind);
+                    e.common = entity_common;
+                    e.acis_data.version = if data.is_binary {
+                        crate::entities::solid3d::AcisVersion::Version2
+                    } else {
+                        crate::entities::solid3d::AcisVersion::Version1
+                    };
+                    e.acis_data.sat_data = data.sat_data;
+                    e.acis_data.sab_data = data.sab_data;
+                    e.acis_data.is_binary = data.is_binary;
+                    e.wires = data.wires;
+                    e.silhouettes = data.silhouettes;
+                    // Preserve the raw object verbatim so DWG write-back keeps
+                    // the original surface type (no native surface encoder yet).
+                    e.dwg_handle_bits = reader.get_handle_bits();
+                    e.raw_dwg_data = Some(reader.raw_merged_data());
+                    let _ = document.add_entity(EntityType::Surface(e));
+                },
+
                 // ── Catch-all ──────────────────────────────────────
                 _ => {
                     let mut e = UnknownEntity::new(format!("DWG_TYPE_{}", type_code));

--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -2498,6 +2498,8 @@ fn map_dimension_common(
     base.version = common.version_byte;
     base.normal = common.normal;
     base.text_middle_point = common.text_middle_point;
+    // Flags byte bit 0: dimension text positioned at a user-defined location.
+    base.text_user_positioned = (common.flags_byte & 0x01) != 0;
     base.text = common.text.clone();
     base.text_rotation = common.text_rotation;
     base.horizontal_direction = common.horizontal_direction;

--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -2437,9 +2437,9 @@ impl DwgDocumentBuilder {
                     obj.front_clip = data.front_clip;
                     obj.back_clip = data.back_clip;
                     obj.inverse_block_transform =
-                        matrix_from_column_major(&data.inverse_block_transform);
+                        matrix_from_row_major(&data.inverse_block_transform);
                     obj.clip_bound_transform =
-                        matrix_from_column_major(&data.clip_bound_transform);
+                        matrix_from_row_major(&data.clip_bound_transform);
                     document.objects.insert(
                         Handle::from(handle),
                         crate::objects::ObjectType::SpatialFilter(obj),
@@ -2545,14 +2545,16 @@ impl DwgDocumentBuilder {
     }
 }
 
-/// Build a [`Matrix4`](crate::types::Matrix4) from 12 doubles holding a 4×3
-/// transform in column-major order (4 columns of 3 rows); bottom row implied.
-fn matrix_from_column_major(v: &[f64; 12]) -> crate::types::Matrix4 {
+/// Build a [`Matrix4`](crate::types::Matrix4) from 12 doubles holding a 3×4
+/// transform in row-major order (3 rows of 4: `[R | t]`); bottom row implied.
+/// DWG stores the spatial-filter transforms row-major (unlike DXF code 40,
+/// which is column-major).
+fn matrix_from_row_major(v: &[f64; 12]) -> crate::types::Matrix4 {
     crate::types::Matrix4 {
         m: [
-            [v[0], v[3], v[6], v[9]],
-            [v[1], v[4], v[7], v[10]],
-            [v[2], v[5], v[8], v[11]],
+            [v[0], v[1], v[2], v[3]],
+            [v[4], v[5], v[6], v[7]],
+            [v[8], v[9], v[10], v[11]],
             [0.0, 0.0, 0.0, 1.0],
         ],
     }

--- a/src/io/dwg/dwg_reader.rs
+++ b/src/io/dwg/dwg_reader.rs
@@ -228,6 +228,7 @@ fn attach_acds_sab_blobs(document: &mut crate::document::CadDocument, blobs: Vec
             EntityType::Solid3D(s) => &mut s.acis_data,
             EntityType::Region(r) => &mut r.acis_data,
             EntityType::Body(b) => &mut b.acis_data,
+            EntityType::Surface(s) => &mut s.acis_data,
             _ => continue,
         };
         match it.next() {

--- a/src/io/dwg/dwg_stream_readers/object_reader/common.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/common.rs
@@ -137,6 +137,9 @@ pub const OBJ_BLOCKVISIBILITYPARAMETER: i16 = 0x84; // 132
 // AcDbBlockRepresentationData — links an anonymous evaluated block back to its
 // dynamic block definition. 0x85 is a free internal sentinel.
 pub const OBJ_BLOCKREPRESENTATIONDATA: i16 = 0x85; // 133
+// AcDbSpatialFilter (XCLIP clip boundary) is always class-based; 0x86 is a free
+// internal sentinel for the class-number map + builder dispatch.
+pub const OBJ_SPATIALFILTER: i16 = 0x86; // 134
 
 /// Returns true if the type code is a graphical entity (not a table / object).
 pub fn is_entity_type(type_code: i16) -> bool {
@@ -193,6 +196,7 @@ pub fn dxf_name_to_type_code(dxf_name: &str) -> Option<i16> {
         "TABLECONTENT" => Some(OBJ_TABLECONTENT),
         "TABLESTYLE" => Some(OBJ_TABLESTYLE),
         "GEODATA" | "ACDBGEODATA" => Some(OBJ_GEODATA),
+        "SPATIAL_FILTER" | "SPATIALFILTER" => Some(OBJ_SPATIALFILTER),
         "BLOCKVISIBILITYPARAMETER" => Some(OBJ_BLOCKVISIBILITYPARAMETER),
         "ACDB_BLOCKREPRESENTATION_DATA" | "BLOCKREPRESENTATION" => {
             Some(OBJ_BLOCKREPRESENTATIONDATA)

--- a/src/io/dwg/dwg_stream_readers/object_reader/common.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/common.rs
@@ -104,6 +104,14 @@ pub const OBJ_IMAGE: i16 = -1;
 pub const OBJ_MESH: i16 = -2;
 pub const OBJ_MULTILEADER: i16 = -3;
 pub const OBJ_WIPEOUT: i16 = -4;
+// ACAD_SURFACE family — ACIS-backed graphical entities resolved by class name.
+pub const OBJ_SURFACE: i16 = -5;
+pub const OBJ_PLANESURFACE: i16 = -6;
+pub const OBJ_EXTRUDEDSURFACE: i16 = -7;
+pub const OBJ_LOFTEDSURFACE: i16 = -8;
+pub const OBJ_REVOLVEDSURFACE: i16 = -9;
+pub const OBJ_SWEPTSURFACE: i16 = -10;
+pub const OBJ_NURBSURFACE: i16 = -11;
 
 // Class-based non-entity objects — also resolved via class mapping for
 // portable type codes.  The values here match ACadSharp's ObjectType.
@@ -137,7 +145,7 @@ pub fn is_entity_type(type_code: i16) -> bool {
     // Class-based entity sentinels: -4..-1 (WIPEOUT, MULTILEADER, MESH, IMAGE)
     // Class-based entity types (≥500) are NOT included here; the builder
     // checks the class's is_an_entity flag directly.
-    matches!(type_code, -4..=-1 | 1..=41 | 43..=47 | 74 | 77 | 78)
+    matches!(type_code, -11..=-1 | 1..=41 | 43..=47 | 74 | 77 | 78)
 }
 
 /// Returns true if the type code is a table control or entry.
@@ -159,6 +167,14 @@ pub fn dxf_name_to_type_code(dxf_name: &str) -> Option<i16> {
         "MESH" => Some(OBJ_MESH),
         "MULTILEADER" => Some(OBJ_MULTILEADER),
         "OLE2FRAME" => Some(OBJ_OLE2FRAME),
+        // ACAD_SURFACE family (ACIS-backed graphical entities).
+        "SURFACE" => Some(OBJ_SURFACE),
+        "PLANESURFACE" => Some(OBJ_PLANESURFACE),
+        "EXTRUDEDSURFACE" => Some(OBJ_EXTRUDEDSURFACE),
+        "LOFTEDSURFACE" => Some(OBJ_LOFTEDSURFACE),
+        "REVOLVEDSURFACE" => Some(OBJ_REVOLVEDSURFACE),
+        "SWEPTSURFACE" => Some(OBJ_SWEPTSURFACE),
+        "NURBSURFACE" => Some(OBJ_NURBSURFACE),
         // Non-entity objects
         "ACDBDICTIONARYWDFLT" => Some(OBJ_DICTIONARYWDFLT),
         "DICTIONARYVAR" => Some(OBJ_DICTIONARYVAR),

--- a/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
@@ -811,6 +811,54 @@ pub fn read_geodata(reader: &mut DwgMergedReader) -> GeoDataData {
     d
 }
 
+/// SpatialFilter (AcDbSpatialFilter) object-specific fields — the XCLIP clip
+/// boundary attached to a block reference.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SpatialFilterData {
+    pub points: Vec<Vector2>,
+    pub extrusion: Vector3,
+    pub clip_bound_origin: Vector3,
+    pub display_enabled: bool,
+    pub front_clip: Option<f64>,
+    pub back_clip: Option<f64>,
+    /// 12 doubles, column-major 4×3 inverse block transform.
+    pub inverse_block_transform: [f64; 12],
+    /// 12 doubles, column-major 4×3 clip bound transform.
+    pub clip_bound_transform: [f64; 12],
+}
+
+/// Read the AcDbSpatialFilter object body (after common non-entity data).
+///
+/// Field order (ODA spec): point count (BS), `count` boundary points (2RD),
+/// boundary plane normal (3BD), clip bound origin (3BD), display-enabled bit,
+/// front-clip bit + optional distance (BD), back-clip bit + optional distance
+/// (BD), then the inverse-block and clip-bound transforms as 12 doubles each
+/// (BD). The two transforms use the same column-major layout as DXF code 40.
+pub fn read_spatial_filter(reader: &mut DwgMergedReader) -> SpatialFilterData {
+    let mut d = SpatialFilterData::default();
+    let num = safe_count(reader.read_bit_short() as i32);
+    for _ in 0..num {
+        d.points.push(reader.read_2raw_double());
+    }
+    d.extrusion = reader.read_3bit_double();
+    d.clip_bound_origin = reader.read_3bit_double();
+    d.display_enabled = reader.read_bit();
+    if reader.read_bit() {
+        d.front_clip = Some(reader.read_bit_double());
+    }
+    if reader.read_bit() {
+        d.back_clip = Some(reader.read_bit_double());
+    }
+    for i in 0..12 {
+        d.inverse_block_transform[i] = reader.read_bit_double();
+    }
+    for i in 0..12 {
+        d.clip_bound_transform[i] = reader.read_bit_double();
+    }
+    d
+}
+
 // ════════════════════════════════════════════════════════════════════════
 //  Tests
 // ════════════════════════════════════════════════════════════════════════
@@ -901,6 +949,35 @@ mod tests {
         assert_eq!(g.coordinate_system_definition, csd);
         assert_eq!(g.geo_rss_tag, "georss-tag");
         assert_eq!(g.observation_coverage_tag, "cov");
+    }
+
+    #[test]
+    fn test_spatial_filter_roundtrip() {
+        let v = DwgVersion::AC15;
+        let d = DxfVersion::AC1015;
+        let mut r = make_reader(v, d, |w| {
+            w.write_bit_short(2); // num boundary points (rectangular clip)
+            w.write_2raw_double(Vector2::new(-5.0, -5.0));
+            w.write_2raw_double(Vector2::new(5.0, 5.0));
+            w.write_3bit_double(Vector3::new(0.0, 0.0, 1.0)); // extrusion
+            w.write_3bit_double(Vector3::new(0.0, 0.0, 0.0)); // clip bound origin
+            w.write_bit(true); // display enabled
+            w.write_bit(true); // front clip on
+            w.write_bit_double(2.5); // front clip dist
+            w.write_bit(false); // back clip off
+            for i in 0..12 { w.write_bit_double(i as f64); } // inverse block transform
+            for i in 0..12 { w.write_bit_double((i + 100) as f64); } // clip bound transform
+        });
+        let sf = read_spatial_filter(&mut r);
+        assert_eq!(sf.points.len(), 2);
+        assert_eq!(sf.points[0], Vector2::new(-5.0, -5.0));
+        assert_eq!(sf.points[1], Vector2::new(5.0, 5.0));
+        assert_eq!(sf.extrusion, Vector3::new(0.0, 0.0, 1.0));
+        assert!(sf.display_enabled);
+        assert_eq!(sf.front_clip, Some(2.5));
+        assert_eq!(sf.back_clip, None);
+        assert_eq!(sf.inverse_block_transform[11], 11.0);
+        assert_eq!(sf.clip_bound_transform[0], 100.0);
     }
 
     #[test]

--- a/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
@@ -831,10 +831,12 @@ pub struct SpatialFilterData {
 /// Read the AcDbSpatialFilter object body (after common non-entity data).
 ///
 /// Field order (ODA spec): point count (BS), `count` boundary points (2RD),
-/// boundary plane normal (3BD), clip bound origin (3BD), display-enabled bit,
-/// front-clip bit + optional distance (BD), back-clip bit + optional distance
-/// (BD), then the inverse-block and clip-bound transforms as 12 doubles each
-/// (BD). The two transforms use the same column-major layout as DXF code 40.
+/// boundary plane normal (3BD), clip bound origin (3BD), display-enabled flag
+/// (BS), front-clip flag (BS) + optional distance (BD), back-clip flag (BS) +
+/// optional distance (BD), then the inverse-block and clip-bound transforms as
+/// 12 doubles each (BD). The three flags mirror DXF codes 71/72/73 (i16), so
+/// they are bit-shorts, not single bits. The transforms use the same
+/// column-major layout as DXF code 40.
 pub fn read_spatial_filter(reader: &mut DwgMergedReader) -> SpatialFilterData {
     let mut d = SpatialFilterData::default();
     let num = safe_count(reader.read_bit_short() as i32);
@@ -843,11 +845,11 @@ pub fn read_spatial_filter(reader: &mut DwgMergedReader) -> SpatialFilterData {
     }
     d.extrusion = reader.read_3bit_double();
     d.clip_bound_origin = reader.read_3bit_double();
-    d.display_enabled = reader.read_bit();
-    if reader.read_bit() {
+    d.display_enabled = reader.read_bit_short() != 0;
+    if reader.read_bit_short() != 0 {
         d.front_clip = Some(reader.read_bit_double());
     }
-    if reader.read_bit() {
+    if reader.read_bit_short() != 0 {
         d.back_clip = Some(reader.read_bit_double());
     }
     for i in 0..12 {
@@ -961,10 +963,10 @@ mod tests {
             w.write_2raw_double(Vector2::new(5.0, 5.0));
             w.write_3bit_double(Vector3::new(0.0, 0.0, 1.0)); // extrusion
             w.write_3bit_double(Vector3::new(0.0, 0.0, 0.0)); // clip bound origin
-            w.write_bit(true); // display enabled
-            w.write_bit(true); // front clip on
+            w.write_bit_short(1); // display enabled
+            w.write_bit_short(1); // front clip on
             w.write_bit_double(2.5); // front clip dist
-            w.write_bit(false); // back clip off
+            w.write_bit_short(0); // back clip off
             for i in 0..12 { w.write_bit_double(i as f64); } // inverse block transform
             for i in 0..12 { w.write_bit_double((i + 100) as f64); } // clip bound transform
         });

--- a/src/io/dwg/dwg_stream_writers/object_writer/common.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/common.rs
@@ -113,6 +113,7 @@ pub const OBJ_SORTENTSTABLE: i16 = 0x7F;    // 127
 pub const OBJ_RASTERVARIABLES: i16 = 0x80;  // 128
 pub const OBJ_DBCOLOR: i16 = 0x81;          // 129
 pub const OBJ_WIPEOUTVARIABLES: i16 = 0x82; // 130
+pub const OBJ_SPATIALFILTER: i16 = 0x86;    // 134 (class-based; sentinel fallback)
 
 // ── Methods on DwgObjectWriter ──────────────────────────────────────
 impl<'a> DwgObjectWriter<'a> {

--- a/src/io/dwg/dwg_stream_writers/object_writer/entities.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/entities.rs
@@ -1443,8 +1443,9 @@ impl<'a> DwgObjectWriter<'a> {
         // Elevation BD 11 Z-coord
         self.writer.write_bit_double(base.text_middle_point.z);
 
-        // Flags byte (0 = text user-defined location)
-        self.writer.write_byte(0);
+        // Flags byte — bit 0: text positioned at a user-defined location.
+        self.writer
+            .write_byte(if base.text_user_positioned { 0x01 } else { 0 });
 
         // User text TV 1
         self.writer.write_variable_text(&base.text);

--- a/src/io/dwg/dwg_stream_writers/object_writer/entities.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/entities.rs
@@ -60,6 +60,20 @@ impl<'a> DwgObjectWriter<'a> {
             EntityType::Solid3D(e) => self.write_solid3d(e),
             EntityType::Region(e) => self.write_region(e),
             EntityType::Body(e) => self.write_body(e),
+            EntityType::Surface(e) => {
+                // Round-trip the surface verbatim from its preserved raw bytes
+                // (no native surface encoder yet). Without raw data we skip it,
+                // exactly like an unknown entity.
+                if let Some(ref raw_data) = e.raw_dwg_data {
+                    self.register_raw_object(e.common.handle, raw_data, e.dwg_handle_bits);
+                    // On R2013+ the ACIS geometry lives in the AcDsPrototype
+                    // section, not the entity record — re-queue it so the SAB
+                    // survives write-back alongside the raw entity stub.
+                    if self.needs_acds_section() {
+                        self.queue_sab_entry(&e.acis_data, e.common.handle);
+                    }
+                }
+            }
             EntityType::Table(_)
             | EntityType::Underlay(_) => {
                 // Not yet supported â€” silently skip

--- a/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
@@ -277,7 +277,9 @@ impl<'a> DwgObjectWriter<'a> {
     /// Currently disabled: always write inline because the DWG reader doesn't yet
     /// parse the AcDsPrototype_1b section, which causes ACIS data loss on read-back.
     fn needs_acds_section(&self) -> bool {
-        false // self.dxf_version >= DxfVersion::AC1027
+        // R2013+ stores ACIS (3DSOLID/REGION/BODY/SURFACE) geometry in the
+        // AcDsPrototype_1b section rather than inline in the entity stream.
+        self.version.r2013_plus(self.dxf_version)
     }
 
     /// Find the root dictionary handle by scanning document.objects.

--- a/src/io/dwg/dwg_stream_writers/object_writer/objects.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/objects.rs
@@ -17,6 +17,20 @@ use crate::types::{DxfVersion, Handle};
 use super::common;
 use super::DwgObjectWriter;
 
+/// Flatten a [`Matrix4`](crate::types::Matrix4) into 12 doubles holding its 4×3
+/// part in column-major order (4 columns of 3 rows); the bottom row is dropped.
+fn matrix_to_column_major(m: &crate::types::Matrix4) -> [f64; 12] {
+    let mut out = [0.0; 12];
+    let mut i = 0;
+    for col in 0..4 {
+        for row in 0..3 {
+            out[i] = m.m[row][col];
+            i += 1;
+        }
+    }
+    out
+}
+
 impl<'a> DwgObjectWriter<'a> {
     // ── Object dispatch ─────────────────────────────────────────────
 
@@ -40,9 +54,9 @@ impl<'a> DwgObjectWriter<'a> {
             ObjectType::PlaceHolder(p) => self.write_placeholder(p),
             ObjectType::BookColor(b) => self.write_book_color(b),
             ObjectType::WipeoutVariables(w) => self.write_wipeout_variables(w),
+            ObjectType::SpatialFilter(s) => self.write_spatial_filter(s),
             // Stub / unsupported objects — skip
             ObjectType::GeoData(_)
-            | ObjectType::SpatialFilter(_)
             | ObjectType::VisualStyle(_)
             | ObjectType::Material(_)
             | ObjectType::TableStyle(_) => {}
@@ -66,7 +80,6 @@ impl<'a> DwgObjectWriter<'a> {
             None => false,
             Some(obj) => match obj {
                 ObjectType::GeoData(_)
-                | ObjectType::SpatialFilter(_)
                 | ObjectType::VisualStyle(_)
                 | ObjectType::Material(_)
                 | ObjectType::TableStyle(_) => false,
@@ -884,6 +897,44 @@ impl<'a> DwgObjectWriter<'a> {
         self.writer.write_bit_short(rv.units);
 
         self.register_object(rv.handle);
+    }
+
+    // ── Spatial Filter (XCLIP clip boundary) ────────────────────────
+
+    fn write_spatial_filter(&mut self, sf: &SpatialFilter) {
+        // UNLISTED type — always use DXF class number (500+)
+        let type_code = self.class_type_code("SPATIAL_FILTER", common::OBJ_SPATIALFILTER);
+        self.write_common_non_entity_data(
+            type_code,
+            sf.handle,
+            sf.owner,
+            &[],
+            &None,
+        );
+
+        self.writer.write_bit_short(sf.boundary_points.len() as i16);
+        for p in &sf.boundary_points {
+            self.writer.write_2raw_double(*p);
+        }
+        self.writer.write_3bit_double(sf.normal);
+        self.writer.write_3bit_double(sf.origin);
+        self.writer.write_bit(sf.display_enabled);
+        self.writer.write_bit(sf.front_clip.is_some());
+        if let Some(d) = sf.front_clip {
+            self.writer.write_bit_double(d);
+        }
+        self.writer.write_bit(sf.back_clip.is_some());
+        if let Some(d) = sf.back_clip {
+            self.writer.write_bit_double(d);
+        }
+        for v in matrix_to_column_major(&sf.inverse_block_transform) {
+            self.writer.write_bit_double(v);
+        }
+        for v in matrix_to_column_major(&sf.clip_bound_transform) {
+            self.writer.write_bit_double(v);
+        }
+
+        self.register_object(sf.handle);
     }
 
     // ── PlaceHolder ─────────────────────────────────────────────────

--- a/src/io/dwg/dwg_stream_writers/object_writer/objects.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/objects.rs
@@ -17,13 +17,14 @@ use crate::types::{DxfVersion, Handle};
 use super::common;
 use super::DwgObjectWriter;
 
-/// Flatten a [`Matrix4`](crate::types::Matrix4) into 12 doubles holding its 4×3
-/// part in column-major order (4 columns of 3 rows); the bottom row is dropped.
-fn matrix_to_column_major(m: &crate::types::Matrix4) -> [f64; 12] {
+/// Flatten a [`Matrix4`](crate::types::Matrix4) into 12 doubles holding its 3×4
+/// part in row-major order (3 rows of 4); the bottom row is dropped. DWG stores
+/// the spatial-filter transforms row-major.
+fn matrix_to_row_major(m: &crate::types::Matrix4) -> [f64; 12] {
     let mut out = [0.0; 12];
     let mut i = 0;
-    for col in 0..4 {
-        for row in 0..3 {
+    for row in 0..3 {
+        for col in 0..4 {
             out[i] = m.m[row][col];
             i += 1;
         }
@@ -918,19 +919,19 @@ impl<'a> DwgObjectWriter<'a> {
         }
         self.writer.write_3bit_double(sf.normal);
         self.writer.write_3bit_double(sf.origin);
-        self.writer.write_bit(sf.display_enabled);
-        self.writer.write_bit(sf.front_clip.is_some());
+        self.writer.write_bit_short(sf.display_enabled as i16);
+        self.writer.write_bit_short(sf.front_clip.is_some() as i16);
         if let Some(d) = sf.front_clip {
             self.writer.write_bit_double(d);
         }
-        self.writer.write_bit(sf.back_clip.is_some());
+        self.writer.write_bit_short(sf.back_clip.is_some() as i16);
         if let Some(d) = sf.back_clip {
             self.writer.write_bit_double(d);
         }
-        for v in matrix_to_column_major(&sf.inverse_block_transform) {
+        for v in matrix_to_row_major(&sf.inverse_block_transform) {
             self.writer.write_bit_double(v);
         }
-        for v in matrix_to_column_major(&sf.clip_bound_transform) {
+        for v in matrix_to_row_major(&sf.clip_bound_transform) {
             self.writer.write_bit_double(v);
         }
 

--- a/src/io/dwg/dwg_writer.rs
+++ b/src/io/dwg/dwg_writer.rs
@@ -809,12 +809,8 @@ fn build_acds_prototype(sab_entries: &[(Handle, Vec<u8>)]) -> Vec<u8> {
         return Vec::new();
     }
 
-    // Use first entry only (extend to multi-entry later if needed).
-    let (entity_handle, sab_data) = &sab_entries[0];
-    let handle_val = entity_handle.value() as u32;
-
-    // ── Segment 1: _data_ id=2 (SAB data records) ─────────────────
-    let data2 = build_acds_data2_segment(handle_val, sab_data);
+    // ── Segment 1: _data_ id=2 (SAB data records, one per ACIS entity) ──
+    let data2 = build_acds_data2_segment(sab_entries);
 
     // ── Segment 2: _data_ id=3 (thumbnail, empty boilerplate) ─────
     #[rustfmt::skip]
@@ -830,7 +826,7 @@ fn build_acds_prototype(sab_entries: &[(Handle, Vec<u8>)]) -> Vec<u8> {
     ];
 
     // ── Segment 3: datidx id=4 ────────────────────────────────────
-    let datidx = build_acds_datidx();
+    let datidx = build_acds_datidx(sab_entries.len());
 
     // ── Segment 4: schdat id=5 (schema definitions, fixed) ────────
     let schdat = ACDS_SCHDAT_TEMPLATE;
@@ -839,7 +835,8 @@ fn build_acds_prototype(sab_entries: &[(Handle, Vec<u8>)]) -> Vec<u8> {
     let schidx = ACDS_SCHIDX_TEMPLATE;
 
     // ── Segment 6: search id=7 ───────────────────────────────────
-    let search = build_acds_search_segment(handle_val);
+    let handles: Vec<u32> = sab_entries.iter().map(|(h, _)| h.value() as u32).collect();
+    let search = build_acds_search_segment(&handles);
 
     // ── Segment 7: segidx id=1 ───────────────────────────────────
     // Compute offsets (all relative to section start = after jard header)
@@ -923,11 +920,15 @@ fn build_acds_jard_header(
     h
 }
 
-/// Build `_data_` segment id=2 containing SAB record(s).
-fn build_acds_data2_segment(handle_val: u32, sab_data: &[u8]) -> Vec<u8> {
-    let sab_len = sab_data.len();
-    // Raw size = 48 (segment header) + 36 (record metadata) + sab_len
-    let raw_size = 84 + sab_len;
+/// Build `_data_` segment id=2 containing one SAB record per ACIS entity.
+///
+/// Each record is a 36-byte metadata block (record index, entity handle, blob
+/// size) followed by the raw SAB blob; records are concatenated in entity
+/// order and the whole segment is padded to a 16-byte boundary.
+fn build_acds_data2_segment(entries: &[(Handle, Vec<u8>)]) -> Vec<u8> {
+    // Raw size = 48 (segment header) + Σ (36 metadata + blob) per record.
+    let records_size: usize = entries.iter().map(|(_, sab)| 36 + sab.len()).sum();
+    let raw_size = 48 + records_size;
     let seg_size = align16(raw_size);
     let padding = seg_size - raw_size;
 
@@ -938,21 +939,22 @@ fn build_acds_data2_segment(handle_val: u32, sab_data: &[u8]) -> Vec<u8> {
     seg.extend_from_slice(&2u32.to_le_bytes()); // id=2
     seg.extend_from_slice(&0u32.to_le_bytes()); // pad
     seg.extend_from_slice(&(seg_size as u64).to_le_bytes()); // segment size
-    seg.extend_from_slice(&1u64.to_le_bytes()); // record count = 1
+    seg.extend_from_slice(&(entries.len() as u64).to_le_bytes()); // record count
     seg.extend_from_slice(&0u32.to_le_bytes()); // meta field1 = 0
     seg.extend_from_slice(&5u32.to_le_bytes()); // meta field2 = 5 (num columns)
     seg.extend_from_slice(&[0x55; 8]); // fill "UUUUUUUU"
 
-    // Record metadata (36 bytes)
-    seg.extend_from_slice(&0x14u32.to_le_bytes()); // col0 = 20
-    seg.extend_from_slice(&1u32.to_le_bytes());     // col1 = record index (1-based)
-    seg.extend_from_slice(&(handle_val as u64).to_le_bytes()); // col2 = entity handle
-    seg.extend_from_slice(&0u32.to_le_bytes());     // col3 = 0
-    seg.extend_from_slice(&[0x62; 12]);              // col4 fill "bbbbbbbbbbbb"
-    seg.extend_from_slice(&(sab_len as u32).to_le_bytes()); // SAB blob size
-
-    // SAB binary data
-    seg.extend_from_slice(sab_data);
+    for (i, (handle, sab_data)) in entries.iter().enumerate() {
+        let handle_val = handle.value() as u32;
+        // Record metadata (36 bytes)
+        seg.extend_from_slice(&0x14u32.to_le_bytes()); // col0 = 20
+        seg.extend_from_slice(&((i + 1) as u32).to_le_bytes()); // col1 = record index (1-based)
+        seg.extend_from_slice(&(handle_val as u64).to_le_bytes()); // col2 = entity handle
+        seg.extend_from_slice(&0u32.to_le_bytes()); // col3 = 0
+        seg.extend_from_slice(&[0x62; 12]); // col4 fill "bbbbbbbbbbbb"
+        seg.extend_from_slice(&(sab_data.len() as u32).to_le_bytes()); // SAB blob size
+        seg.extend_from_slice(sab_data); // SAB binary data
+    }
 
     // Padding with 0x70 to 16-byte alignment
     seg.extend(std::iter::repeat(0x70u8).take(padding));
@@ -961,78 +963,75 @@ fn build_acds_data2_segment(handle_val: u32, sab_data: &[u8]) -> Vec<u8> {
     seg
 }
 
-/// Build `datidx` segment id=4.
-fn build_acds_datidx() -> Vec<u8> {
-    let mut seg = vec![0x70u8; 128];
+/// Build `datidx` segment id=4 — one index entry per ACIS record.
+fn build_acds_datidx(num_records: usize) -> Vec<u8> {
+    let num = num_records.max(1);
+    // 48-byte header + 20 bytes per index entry, padded to 16-byte alignment.
+    let raw = 48 + num * 20;
+    let seg_size = align16(raw).max(128);
+    let mut seg = vec![0x70u8; seg_size];
 
     // Segment header
     seg[0..8].copy_from_slice(&[0xAC, 0xD5, 0x64, 0x61, 0x74, 0x69, 0x64, 0x78]); // "datidx"
-    seg[8..12].copy_from_slice(&4u32.to_le_bytes());    // id=4
-    seg[12..16].copy_from_slice(&0u32.to_le_bytes());   // pad
-    seg[16..24].copy_from_slice(&128u64.to_le_bytes()); // segment size
-    seg[24..32].copy_from_slice(&1u64.to_le_bytes());   // record count
-    seg[32..40].copy_from_slice(&0u64.to_le_bytes());   // meta
-    seg[40..48].copy_from_slice(&[0x55; 8]);             // fill
+    seg[8..12].copy_from_slice(&4u32.to_le_bytes()); // id=4
+    seg[12..16].copy_from_slice(&0u32.to_le_bytes()); // pad
+    seg[16..24].copy_from_slice(&(seg_size as u64).to_le_bytes()); // segment size
+    seg[24..32].copy_from_slice(&(num as u64).to_le_bytes()); // record count
+    seg[32..40].copy_from_slice(&0u64.to_le_bytes()); // meta
+    seg[40..48].copy_from_slice(&[0x55; 8]); // fill
 
-    // Content: index entries
-    // (row_index=1, schema_id=2, data_count=1)
-    seg[48..52].copy_from_slice(&1u32.to_le_bytes());
-    seg[52..56].copy_from_slice(&0u32.to_le_bytes());
-    seg[56..60].copy_from_slice(&2u32.to_le_bytes());
-    seg[60..64].copy_from_slice(&0u32.to_le_bytes());
-    seg[64..68].copy_from_slice(&1u32.to_le_bytes());
-    // Rest is padding (already 0x70)
+    // Index entries: (row_index, 0, schema_id=2, 0, data_count=1) — 20 bytes each.
+    let mut pos = 48;
+    for i in 0..num {
+        seg[pos..pos + 4].copy_from_slice(&((i + 1) as u32).to_le_bytes());
+        seg[pos + 4..pos + 8].copy_from_slice(&0u32.to_le_bytes());
+        seg[pos + 8..pos + 12].copy_from_slice(&2u32.to_le_bytes());
+        seg[pos + 12..pos + 16].copy_from_slice(&0u32.to_le_bytes());
+        seg[pos + 16..pos + 20].copy_from_slice(&1u32.to_le_bytes());
+        pos += 20;
+    }
 
     seg
 }
 
-/// Build `search` segment id=7 with entity handle reference.
-fn build_acds_search_segment(handle_val: u32) -> Vec<u8> {
-    let mut seg = vec![0x70u8; 192];
+/// Build `search` segment id=7 with one handle→record lookup per ACIS entity.
+fn build_acds_search_segment(handles: &[u32]) -> Vec<u8> {
+    let num = handles.len().max(1);
+    // 48-byte header + a small fixed preamble + 8 bytes per handle entry,
+    // padded to 16-byte alignment (kept at least the reference 192 bytes).
+    let preamble = 36usize;
+    let raw = 48 + preamble + num * 8;
+    let seg_size = align16(raw).max(192);
+    let mut seg = vec![0x70u8; seg_size];
 
     // Segment header
     seg[0..8].copy_from_slice(&[0xAC, 0xD5, 0x73, 0x65, 0x61, 0x72, 0x63, 0x68]); // "search"
-    seg[8..12].copy_from_slice(&7u32.to_le_bytes());    // id=7
-    seg[12..16].copy_from_slice(&0u32.to_le_bytes());   // pad
-    seg[16..24].copy_from_slice(&192u64.to_le_bytes()); // segment size
-    seg[24..32].copy_from_slice(&1u64.to_le_bytes());   // record count
-    seg[32..40].copy_from_slice(&0u64.to_le_bytes());   // meta
-    seg[40..48].copy_from_slice(&[0x55; 8]);             // fill
+    seg[8..12].copy_from_slice(&7u32.to_le_bytes()); // id=7
+    seg[12..16].copy_from_slice(&0u32.to_le_bytes()); // pad
+    seg[16..24].copy_from_slice(&(seg_size as u64).to_le_bytes()); // segment size
+    seg[24..32].copy_from_slice(&(num as u64).to_le_bytes()); // record count
+    seg[32..40].copy_from_slice(&0u64.to_le_bytes()); // meta
+    seg[40..48].copy_from_slice(&[0x55; 8]); // fill
 
-    // Content (matches reference file layout)
-    // Search index entries
+    // Preamble (matches reference file layout for the schema-with-data table).
     let content: &[u8] = &[
         0x02, 0x00, 0x00, 0x00, // num_schemas_with_data = 2
-        0x01, 0x00, 0x00, 0x00, // ?
-        0x01, 0x00, 0x00, 0x00, // ?
+        0x01, 0x00, 0x00, 0x00, //
+        0x01, 0x00, 0x00, 0x00, //
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // zeros
-        0x00, 0x00, 0x00, 0x00, // ?
-        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ?
-        0x01, 0x00, 0x00, 0x00, // ?
+        0x00, 0x00, 0x00, 0x00, //
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
+        0x01, 0x00, 0x00, 0x00, //
     ];
     seg[48..48 + content.len()].copy_from_slice(content);
 
-    // Entity handle at offset 0x54 from segment start (= 48 + 36 = 84)
-    // Actually from the dump: handle "2A" is at segment offset +0x54
-    // = content offset 0x54 - 0x30 = 0x24 from content start (48 + 36 = 84)
-    // Let me recalculate: segment starts at 0x19C0 in reference,
-    // handle 0x2A at 0x1A14 = 0x19C0 + 0x54.
-    // So offset within segment is 0x54 = 84.
-    seg[84..88].copy_from_slice(&handle_val.to_le_bytes());
-    seg[88..92].copy_from_slice(&0u32.to_le_bytes()); // pad
-
-    // Remaining fields after handle
-    let tail: &[u8] = &[
-        0x01, 0x00, 0x00, 0x00, // ?
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // zeros
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // zeros
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // zeros
-        0x00, 0x00, 0x00, 0x00, // zeros
-        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ?
-        0x00, 0x00, 0x00, 0x00, // ?
-    ];
-    seg[92..92 + tail.len()].copy_from_slice(tail);
-    // Rest is padding (already 0x70)
+    // Handle→record entries: (handle u32, record_index u32) at offset 84.
+    let mut pos = 84;
+    for (i, &handle_val) in handles.iter().enumerate() {
+        seg[pos..pos + 4].copy_from_slice(&handle_val.to_le_bytes());
+        seg[pos + 4..pos + 8].copy_from_slice(&((i + 1) as u32).to_le_bytes());
+        pos += 8;
+    }
 
     seg
 }

--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -3255,6 +3255,7 @@ impl<'a> SectionReader<'a> {
         use crate::entities::dimension::*;
 
         let mut dim_type = DimensionType::Linear;
+        let mut text_user_positioned = false;
         let mut definition_point = PointReader::new();
         let mut text_middle_point = PointReader::new();
         let mut insertion_point = PointReader::new();
@@ -3304,6 +3305,9 @@ impl<'a> SectionReader<'a> {
                             6 => DimensionType::Ordinate,
                             _ => DimensionType::Linear,
                         };
+                        // Bit 0x80: text was positioned at a user-defined
+                        // location rather than the style default.
+                        text_user_positioned = (type_val & 0x80) != 0;
                     }
                 }
                 1 => text = pair.value_string.clone(),
@@ -3451,6 +3455,7 @@ impl<'a> SectionReader<'a> {
             if let Some(pt) = text_middle_point.get_point() {
                 dc.text_middle_point = pt;
             }
+            dc.text_user_positioned = text_user_positioned;
             if let Some(pt) = definition_point.get_point() {
                 dc.definition_point = pt;
             }

--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -10,6 +10,20 @@ use crate::tables::linetype::LineTypeElement;
 use crate::types::*;
 use crate::xdata::{ExtendedData, ExtendedDataRecord, XDataValue};
 
+/// Build a [`Matrix4`] from 12 doubles holding a 4×3 transform in DXF
+/// column-major order (4 columns of 3 rows each). The implied bottom row is
+/// `[0, 0, 0, 1]`.
+fn matrix_from_column_major(v: &[f64]) -> Matrix4 {
+    Matrix4 {
+        m: [
+            [v[0], v[3], v[6], v[9]],
+            [v[1], v[4], v[7], v[10]],
+            [v[2], v[5], v[8], v[11]],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+    }
+}
+
 /// States for the mesh reading state machine
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MeshReadState {
@@ -1140,8 +1154,9 @@ impl<'a> SectionReader<'a> {
                         document.objects.insert(obj.handle, ObjectType::GeoData(obj));
                     }
                     "SPATIALFILTER" => {
-                        let obj = self.read_stub_object::<SpatialFilter>()?;
-                        document.objects.insert(obj.handle, ObjectType::SpatialFilter(obj));
+                        if let Some(obj) = self.read_spatial_filter()? {
+                            document.objects.insert(obj.handle, ObjectType::SpatialFilter(obj));
+                        }
                     }
                     "RASTERVARIABLES" => {
                         if let Some(obj) = self.read_raster_variables()? {
@@ -1436,6 +1451,71 @@ impl<'a> SectionReader<'a> {
                 330 => { if let Ok(h) = u64::from_str_radix(&pair.value_string, 16) { obj.owner = Handle::new(h); } }
                 _ => {}
             }
+        }
+        Ok(Some(obj))
+    }
+
+    /// Read a SPATIAL_FILTER object (block reference / XCLIP clip boundary).
+    ///
+    /// Group code layout (AcDbSpatialFilter):
+    ///   70  number of boundary points
+    ///   10/20  boundary point (2D), repeated `count` times
+    ///   210/220/230  boundary plane normal
+    ///   11/21/31  clip boundary local origin
+    ///   71  display enabled flag
+    ///   72  front clip flag, 40 front clip distance (only when 72 set)
+    ///   73  back clip flag, 41 back clip distance (only when 73 set)
+    ///   40 ×12  inverse block transform (column-major 4×3)
+    ///   40 ×12  clip bound transform (column-major 4×3)
+    ///
+    /// The front clip distance reuses code 40, so the first code-40 value is
+    /// treated as the front distance only while the front flag is set and no
+    /// matrix values have been read yet; all later code-40 values feed the two
+    /// transformation matrices.
+    fn read_spatial_filter(&mut self) -> Result<Option<SpatialFilter>> {
+        let mut obj = SpatialFilter::new();
+        let mut front_flag = false;
+        let mut pending_x: Option<f64> = None;
+        let mut mat: Vec<f64> = Vec::new();
+        while let Some(pair) = self.reader.read_pair()? {
+            if pair.code == 0 { self.reader.push_back(pair); break; }
+            match pair.code {
+                5 => { if let Ok(h) = u64::from_str_radix(&pair.value_string, 16) { obj.handle = Handle::new(h); } }
+                330 => { if let Ok(h) = u64::from_str_radix(&pair.value_string, 16) { obj.owner = Handle::new(h); } }
+                70 => {} // point count is implied by the 10/20 pairs we read
+                10 => { if let Some(v) = pair.as_double() { pending_x = Some(v); } }
+                20 => {
+                    if let (Some(x), Some(y)) = (pending_x.take(), pair.as_double()) {
+                        obj.boundary_points.push(Vector2::new(x, y));
+                    }
+                }
+                210 => { if let Some(v) = pair.as_double() { obj.normal.x = v; } }
+                220 => { if let Some(v) = pair.as_double() { obj.normal.y = v; } }
+                230 => { if let Some(v) = pair.as_double() { obj.normal.z = v; } }
+                11 => { if let Some(v) = pair.as_double() { obj.origin.x = v; } }
+                21 => { if let Some(v) = pair.as_double() { obj.origin.y = v; } }
+                31 => { if let Some(v) = pair.as_double() { obj.origin.z = v; } }
+                71 => { obj.display_enabled = pair.as_i16().map(|v| v != 0).unwrap_or(true); }
+                72 => { front_flag = pair.as_i16().map(|v| v != 0).unwrap_or(false); }
+                73 => {} // back clip distance arrives as code 41 below
+                40 => {
+                    if let Some(v) = pair.as_double() {
+                        if front_flag && obj.front_clip.is_none() && mat.is_empty() {
+                            obj.front_clip = Some(v);
+                        } else {
+                            mat.push(v);
+                        }
+                    }
+                }
+                41 => { if let Some(v) = pair.as_double() { obj.back_clip = Some(v); } }
+                _ => {}
+            }
+        }
+        if mat.len() >= 12 {
+            obj.inverse_block_transform = matrix_from_column_major(&mat[0..12]);
+        }
+        if mat.len() >= 24 {
+            obj.clip_bound_transform = matrix_from_column_major(&mat[12..24]);
         }
         Ok(Some(obj))
     }

--- a/src/io/dxf/writer/section_writer.rs
+++ b/src/io/dxf/writer/section_writer.rs
@@ -9,7 +9,7 @@ use crate::error::Result;
 use crate::objects::{
     Dictionary, DictionaryVariable, DictionaryWithDefault, Group, ImageDefinition,
     ImageDefinitionReactor, Layout, MLineStyle, Material, MultiLeaderStyle,
-    ObjectType, PlotSettings, RasterVariables, Scale, SortEntitiesTable,
+    ObjectType, PlotSettings, RasterVariables, Scale, SortEntitiesTable, SpatialFilter,
     TableStyle, VisualStyle, BookColor, WipeoutVariables, XRecord,
 };
 use crate::tables::*;
@@ -2370,7 +2370,7 @@ impl<'a, W: DxfStreamWriter> SectionWriter<'a, W> {
                 ObjectType::Material(obj) => self.write_material(obj)?,
                 ObjectType::ImageDefinitionReactor(obj) => self.write_imagedef_reactor(obj)?,
                 ObjectType::GeoData(obj) => self.write_stub_handle_only("GEODATA", obj.handle, obj.owner)?,
-                ObjectType::SpatialFilter(obj) => self.write_stub_handle_only("SPATIAL_FILTER", obj.handle, obj.owner)?,
+                ObjectType::SpatialFilter(obj) => self.write_spatial_filter(obj)?,
                 ObjectType::RasterVariables(obj) => self.write_raster_variables(obj)?,
                 ObjectType::BookColor(obj) => self.write_bookcolor(obj)?,
                 ObjectType::PlaceHolder(obj) => self.write_stub_handle_only("ACDBPLACEHOLDER", obj.handle, obj.owner)?,
@@ -3101,6 +3101,48 @@ impl<'a, W: DxfStreamWriter> SectionWriter<'a, W> {
         self.writer.write_subclass("AcDbRasterImageDefReactor")?;
         self.writer.write_i32(90, 2)?; // class version
         self.writer.write_handle(330, obj.image_handle)?;
+        Ok(())
+    }
+
+    /// Write a SPATIAL_FILTER object (block reference / XCLIP clip boundary).
+    ///
+    /// Inverse of [`read_spatial_filter`]. The two 4×3 transforms are emitted
+    /// as 12 code-40 doubles each, in column-major order, after the front/back
+    /// clip flags and distances.
+    fn write_spatial_filter(&mut self, obj: &SpatialFilter) -> Result<()> {
+        self.writer.write_string(0, "SPATIAL_FILTER")?;
+        self.writer.write_handle(5, obj.handle)?;
+        self.writer.write_handle(330, obj.owner)?;
+        self.writer.write_subclass("AcDbFilter")?;
+        self.writer.write_subclass("AcDbSpatialFilter")?;
+        self.writer.write_i16(70, obj.boundary_points.len() as i16)?;
+        for p in &obj.boundary_points {
+            self.writer.write_point2d(10, *p)?;
+        }
+        self.writer.write_point3d(210, obj.normal)?;
+        self.writer.write_point3d(11, obj.origin)?;
+        self.writer.write_i16(71, obj.display_enabled as i16)?;
+        self.writer.write_i16(72, obj.front_clip.is_some() as i16)?;
+        if let Some(d) = obj.front_clip {
+            self.writer.write_double(40, d)?;
+        }
+        self.writer.write_i16(73, obj.back_clip.is_some() as i16)?;
+        if let Some(d) = obj.back_clip {
+            self.writer.write_double(41, d)?;
+        }
+        self.write_matrix_column_major(&obj.inverse_block_transform)?;
+        self.write_matrix_column_major(&obj.clip_bound_transform)?;
+        Ok(())
+    }
+
+    /// Write a 4×3 transform as 12 code-40 doubles in DXF column-major order
+    /// (4 columns of 3 rows; the bottom matrix row is implied).
+    fn write_matrix_column_major(&mut self, m: &crate::types::Matrix4) -> Result<()> {
+        for col in 0..4 {
+            for row in 0..3 {
+                self.writer.write_double(40, m.m[row][col])?;
+            }
+        }
         Ok(())
     }
 

--- a/src/io/dxf/writer/section_writer.rs
+++ b/src/io/dxf/writer/section_writer.rs
@@ -1583,6 +1583,12 @@ impl<'a, W: DxfStreamWriter> SectionWriter<'a, W> {
         self.writer.write_string(2, &base.block_name)?;
         self.writer.write_point3d(10, base.definition_point)?;
         self.writer.write_point3d(11, base.text_middle_point)?;
+        // Bit 0x80 marks text positioned at a user-defined location.
+        let type_flags = if base.text_user_positioned {
+            type_flags | 0x80
+        } else {
+            type_flags
+        };
         self.writer.write_i16(70, type_flags)?;
         self.writer.write_double(53, base.text_rotation)?;
         self.writer.write_string(3, &base.style_name)?;

--- a/src/io/dxf/writer/section_writer.rs
+++ b/src/io/dxf/writer/section_writer.rs
@@ -1030,6 +1030,9 @@ impl<'a, W: DxfStreamWriter> SectionWriter<'a, W> {
             EntityType::Solid3D(e) => self.write_solid3d(e, owner),
             EntityType::Region(e) => self.write_region(e, owner),
             EntityType::Body(e) => self.write_body(e, owner),
+            // DXF surface export not yet supported; skip rather than emit
+            // malformed geometry.
+            EntityType::Surface(_) => Ok(()),
             EntityType::Table(e) => self.write_acad_table(e, owner),
             EntityType::Tolerance(e) => self.write_tolerance(e, owner),
             EntityType::PolyfaceMesh(e) => self.write_polyface_mesh(e, owner),

--- a/src/objects/stub_objects.rs
+++ b/src/objects/stub_objects.rs
@@ -3,7 +3,7 @@
 //! These are minimal representations of DXF objects that ACadSharp supports
 //! but that don't require full rich data models for typical usage.
 
-use crate::types::{Handle, Vector2, Vector3};
+use crate::types::{Handle, Matrix4, Vector2, Vector3};
 
 /// Trait for minimal stub objects that only need handle + owner fields.
 /// Used by the generic `read_stub_object` reader.
@@ -190,7 +190,12 @@ impl Default for GeoData {
     fn default() -> Self { Self::new() }
 }
 
-/// SpatialFilter — clip boundary for external references
+/// SpatialFilter — the clip boundary (XCLIP) attached to a block reference.
+///
+/// Stored under the INSERT's extension dictionary as the `SPATIAL` entry of
+/// the `ACAD_FILTER` sub-dictionary. The boundary points are 2D coordinates in
+/// the clip boundary's local coordinate system; two transforms relate that
+/// system to the block reference and to the world.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpatialFilter {
@@ -198,6 +203,28 @@ pub struct SpatialFilter {
     pub handle: Handle,
     /// Owner handle
     pub owner: Handle,
+    /// Clip boundary definition points (code 10/20), in the boundary's local
+    /// 2D coordinate system. Two points = rectangular clip (min/max corners);
+    /// three or more = polygonal clip.
+    pub boundary_points: Vec<Vector2>,
+    /// Normal to the plane of the clip boundary (code 210/220/230).
+    pub normal: Vector3,
+    /// Origin of the clip boundary local coordinate system (code 11/21/31).
+    pub origin: Vector3,
+    /// Clip boundary display enabled flag (code 71).
+    pub display_enabled: bool,
+    /// Front clipping plane distance (code 40), `Some` when the front clip
+    /// flag (code 72) is set.
+    pub front_clip: Option<f64>,
+    /// Back clipping plane distance (code 41), `Some` when the back clip
+    /// flag (code 73) is set.
+    pub back_clip: Option<f64>,
+    /// 4×3 matrix (column-major in DXF) transforming WCS points into the
+    /// block-definition coordinate system — the inverse block transform.
+    pub inverse_block_transform: Matrix4,
+    /// 4×3 matrix transforming clip boundary points into the block reference
+    /// coordinate system.
+    pub clip_bound_transform: Matrix4,
 }
 
 impl SpatialFilter {
@@ -206,6 +233,14 @@ impl SpatialFilter {
         SpatialFilter {
             handle: Handle::NULL,
             owner: Handle::NULL,
+            boundary_points: Vec::new(),
+            normal: Vector3::new(0.0, 0.0, 1.0),
+            origin: Vector3::new(0.0, 0.0, 0.0),
+            display_enabled: true,
+            front_clip: None,
+            back_clip: None,
+            inverse_block_transform: Matrix4::identity(),
+            clip_bound_transform: Matrix4::identity(),
         }
     }
 }
@@ -381,5 +416,4 @@ macro_rules! impl_stub_object {
 }
 
 impl_stub_object!(GeoData);
-impl_stub_object!(SpatialFilter);
 impl_stub_object!(PlaceHolder);


### PR DESCRIPTION
Adds a first-class `Surface` entity for the ACAD_SURFACE family (plane / extruded / lofted / revolved / swept / NURB surfaces), which are ACIS-backed like `Body` but were previously dropped on load.

## Changes
- **New `Surface` entity** (`EntityType::Surface`) + `SurfaceKind`, wired through the entity dispatch, transform / translate / explode, and the DXF/DWG readers and writers.
- **DWG reader:** recognise the ACAD_SURFACE class names as graphical entities, read their ACIS data, and attach AcDs SAB blobs to surfaces alongside solids/bodies/regions.
- **SAB reader:** handle subtype-block delimiters (`0x0F`/`0x10`) and nested type names so spline / lofted surfaces parse instead of failing with `UnknownTag`.
- **DWG writer:** enable the `AcDsPrototype_1b` section for R2013+ and extend it to multiple ACIS records, so surface (and multi-solid) geometry round-trips. Surfaces are written verbatim from preserved raw bytes plus their re-queued SAB blob.

## Testing
- `cargo test --lib` — all 1119 tests pass.
- Round-trip verified on real DWGs: a lofted surface and a 2-solid file read → write → read back with geometry preserved.

Note: AutoCAD-compatibility of the multi-entry AcDs write follows the documented format and round-trips through this reader, but wasn't verified against AutoCAD directly.