### PR TITLE
fix(acis): read SatLoop next_loop from the correct token

### DIFF
--- a/src/entities/acis/types.rs
+++ b/src/entities/acis/types.rs
@@ -693,9 +693,11 @@ impl<'a> SatLoop<'a> {
         }
     }
 
-    /// Pointer to the next loop.
+    /// Pointer to the next loop in the face's loop list (the inner/hole loops
+    /// follow the outer boundary here). The first token is a leading pointer
+    /// (loop kind / unused); the next-loop link is the second.
     pub fn next_loop(&self) -> SatPointer {
-        self.record.token_pointer(0).unwrap_or(SatPointer::NULL)
+        self.record.token_pointer(1).unwrap_or(SatPointer::NULL)
     }
 
     /// Pointer to the first coedge.


### PR DESCRIPTION
## Problem

A SAB `loop` record's next-loop link is the **second** pointer token, not the first (the first is a leading loop-kind / unused pointer). `SatLoop::next_loop()` read token 0, which is always NULL here, so a face's inner (hole) loops were never reached by `first_loop()` → `next_loop()` traversal.

The visible effect: a pierced planar face (e.g. a wall with a window opening) only exposed its outer boundary, so it tessellated/rendered as if solid — the hole was filled.

## Evidence

For a 3DSOLID wall (10 faces / 12 loops), loop records are laid out:

```
single-loop face:       tokens = [-1, -1, $coedge, $face]
pierced face outer loop: tokens = [-1, $hole_loop, $coedge, $face]   ← next-loop is token 1
hole loop:               tokens = [-1, -1, $coedge, $face]           ← same $face
```

Reading token 0 yielded NULL for every loop; reading token 1 chains the outer loop to its hole loop (both sharing the same owner face). After the fix, the wall's two pierced faces correctly report 2 loops each.

## Fix

`SatLoop::next_loop()` reads `token_pointer(1)`. Single-loop faces are unaffected (both token 0 and 1 are NULL); only pierced faces gain their hole loops.

Reported downstream as an OpenCADStudio 3D-solid rendering bug.