### PR TITLE
fix(dwg/acis): viewport + layout round-trip, block-header sync, ACIS loop & transform fixes

### DIFF
--- a/src/entities/acis/types.rs
+++ b/src/entities/acis/types.rs
@@ -677,7 +677,14 @@ impl<'a> SatFace<'a> {
 
 /// Accessor for a `loop` entity record.
 ///
-/// Loop record layout: `loop $<attrib> <id> $<next_loop> $<unknown> $<coedge> $<face>`
+/// Loop record layout: `loop $<attrib> <id> $<pattern> $<next_loop> $<coedge> $<face>`
+///
+/// The leading `$<pattern>` pointer is the ACIS pattern-feature reference
+/// (present from the PATTERN save version on, NULL in practice). There is no
+/// outer-vs-hole / loop-type field: ACIS does not record which loop is the
+/// outer boundary and which are holes — the kernel classifies them at runtime
+/// from geometry (coedge winding vs the face's outward normal). Consumers must
+/// derive the distinction themselves.
 #[derive(Debug, Clone)]
 pub struct SatLoop<'a> {
     record: &'a SatRecord,
@@ -693,9 +700,10 @@ impl<'a> SatLoop<'a> {
         }
     }
 
-    /// Pointer to the next loop in the face's loop list (the inner/hole loops
-    /// follow the outer boundary here). The first token is a leading pointer
-    /// (loop kind / unused); the next-loop link is the second.
+    /// Pointer to the next loop in the face's loop list. The first token is the
+    /// ACIS pattern-feature pointer (NULL in practice); the next-loop link is
+    /// the second. Loop order is not significant — the outer boundary is not
+    /// guaranteed to come first.
     pub fn next_loop(&self) -> SatPointer {
         self.record.token_pointer(1).unwrap_or(SatPointer::NULL)
     }

--- a/src/entities/acis/types.rs
+++ b/src/entities/acis/types.rs
@@ -693,9 +693,11 @@ impl<'a> SatLoop<'a> {
         }
     }
 
-    /// Pointer to the next loop.
+    /// Pointer to the next loop in the face's loop list (the inner/hole loops
+    /// follow the outer boundary here). The first token is a leading pointer
+    /// (loop kind / unused); the next-loop link is the second.
     pub fn next_loop(&self) -> SatPointer {
-        self.record.token_pointer(0).unwrap_or(SatPointer::NULL)
+        self.record.token_pointer(1).unwrap_or(SatPointer::NULL)
     }
 
     /// Pointer to the first coedge.

--- a/src/entities/acis/types.rs
+++ b/src/entities/acis/types.rs
@@ -1310,6 +1310,69 @@ impl SatDocument {
         SatWriter::write(self)
     }
 
+    /// Read the body placement as `(matrix_rowmajor, translation, scale)` in
+    /// the SAT convention `world = scale·(p·M) + T`. Returns identity when the
+    /// document has no `transform` record. The first 13 numeric tokens of the
+    /// transform record carry the 3×3, translation and scale; the leading
+    /// book-keeping pointer and trailing rotate/reflect/shear flags are
+    /// skipped by reading float-valued tokens only.
+    pub fn placement(&self) -> ([[f64; 3]; 3], [f64; 3], f64) {
+        const IDENTITY: ([[f64; 3]; 3], [f64; 3], f64) =
+            ([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], [0.0; 3], 1.0);
+        let Some(rec) = self.records.iter().find(|r| r.entity_type == "transform") else {
+            return IDENTITY;
+        };
+        let v: Vec<f64> = rec.tokens.iter().filter_map(|t| t.as_float()).take(13).collect();
+        if v.len() < 13 {
+            return IDENTITY;
+        }
+        (
+            [[v[0], v[1], v[2]], [v[3], v[4], v[5]], [v[6], v[7], v[8]]],
+            [v[9], v[10], v[11]],
+            v[12],
+        )
+    }
+
+    /// Set the body placement, creating the `transform` record (and wiring the
+    /// body's transform pointer) when absent. Encodes the 3×3, translation and
+    /// scale in the layout `placement()` reads back.
+    pub fn set_placement(&mut self, matrix: [[f64; 3]; 3], translation: [f64; 3], scale: f64) {
+        let mut tokens = Vec::with_capacity(17);
+        tokens.push(SatToken::Pointer(SatPointer::NULL)); // v700 book-keeping
+        for row in &matrix {
+            for &x in row {
+                tokens.push(SatToken::Float(x));
+            }
+        }
+        for &x in &translation {
+            tokens.push(SatToken::Float(x));
+        }
+        tokens.push(SatToken::Float(scale));
+        // rotate / reflect / shear — a composed matrix may be non-orthogonal,
+        // so flag it as a general (shear) placement.
+        tokens.push(SatToken::Integer(0));
+        tokens.push(SatToken::Integer(0));
+        tokens.push(SatToken::Integer(1));
+
+        if let Some(rec) = self.records.iter_mut().find(|r| r.entity_type == "transform") {
+            rec.tokens = tokens;
+            return;
+        }
+        let index = self.records.len() as i32;
+        let mut rec = SatRecord::new(index, "transform");
+        rec.attribute = SatPointer::NULL;
+        rec.tokens = tokens;
+        self.records.push(rec);
+        self.header.num_records = self.records.len();
+        // Wire the first body's transform pointer (4th pointer token:
+        // next_body, lump, wire, transform).
+        if let Some(body) = self.records.iter_mut().find(|r| r.entity_type == "body") {
+            if body.tokens.len() >= 4 {
+                body.tokens[3] = SatToken::Pointer(SatPointer::new(index));
+            }
+        }
+    }
+
     /// Returns the number of entity records.
     pub fn record_count(&self) -> usize {
         self.records.len()

--- a/src/entities/acis/types.rs
+++ b/src/entities/acis/types.rs
@@ -1358,12 +1358,22 @@ impl SatDocument {
             rec.tokens = tokens;
             return;
         }
+        // No transform record yet — append one. Records are position-indexed,
+        // and the `End-of-ACIS-data` / `End-of-ASM-data` terminator must stay
+        // last (the parser stops there). Lift any terminator off, push the
+        // transform, then restore the terminator so it remains final;
+        // otherwise the new record sits past the terminator and is dropped on
+        // the next parse.
+        let terminator = self
+            .records
+            .iter()
+            .position(|r| r.entity_type.starts_with("End-of"))
+            .map(|p| self.records.remove(p));
         let index = self.records.len() as i32;
         let mut rec = SatRecord::new(index, "transform");
         rec.attribute = SatPointer::NULL;
         rec.tokens = tokens;
         self.records.push(rec);
-        self.header.num_records = self.records.len();
         // Wire the first body's transform pointer (4th pointer token:
         // next_body, lump, wire, transform).
         if let Some(body) = self.records.iter_mut().find(|r| r.entity_type == "body") {
@@ -1371,6 +1381,10 @@ impl SatDocument {
                 body.tokens[3] = SatToken::Pointer(SatPointer::new(index));
             }
         }
+        if let Some(term) = terminator {
+            self.records.push(term);
+        }
+        self.header.num_records = self.records.len();
     }
 
     /// Returns the number of entity records.

--- a/src/entities/solid3d.rs
+++ b/src/entities/solid3d.rs
@@ -342,6 +342,37 @@ impl AcisData {
     pub fn from_sat_document(doc: &crate::entities::acis::SatDocument) -> Self {
         Self::from_sat(&doc.to_sat_string())
     }
+
+    /// Parse the ACIS payload into a [`SatDocument`], decoding binary SAB via
+    /// the SAB reader. `None` when the data is empty or cannot be parsed.
+    /// Unlike [`parse_sat`](Self::parse_sat), this also handles binary data.
+    pub fn parse(&self) -> Option<crate::entities::acis::SatDocument> {
+        if self.is_binary {
+            if self.sab_data.is_empty() {
+                return None;
+            }
+            crate::entities::acis::SabReader::read(&self.sab_data).ok()
+        } else {
+            if self.sat_data.is_empty() {
+                return None;
+            }
+            crate::entities::acis::SatDocument::parse(&self.sat_data).ok()
+        }
+    }
+
+    /// The body's placement origin in world space: the translation of the
+    /// ACIS `transform` record. `None` when the data has no transform record
+    /// (geometry baked at world coordinates) or can't be parsed. A 3D solid
+    /// carries no insertion point of its own, so this placement is its natural
+    /// reference point.
+    pub fn placement_origin(&self) -> Option<Vector3> {
+        let doc = self.parse()?;
+        if !doc.records.iter().any(|r| r.entity_type == "transform") {
+            return None;
+        }
+        let (_m, t, _s) = doc.placement();
+        Some(Vector3::new(t[0], t[1], t[2]))
+    }
 }
 
 impl AcisData {

--- a/src/entities/transform.rs
+++ b/src/entities/transform.rs
@@ -4,7 +4,62 @@
 //! function, and [`EntityType`] exposes a convenience dispatch method.
 
 use super::*;
+use crate::entities::solid3d::AcisData;
 use crate::types::{Matrix3, Transform, Vector2, Vector3};
+
+/// Compose `transform` into an ACIS body's placement (the SAT `transform`
+/// record) so the solid's actual geometry moves/rotates/scales, instead of
+/// only nudging a reference point. ACIS keeps geometry in body-local space
+/// and a `transform` record places it into the world as `world = scale·(p·M)
+/// + T`; we fold the incoming world transform into that placement and bake
+/// the result into a single 3×3 (scale = 1), which the tessellator applies
+/// verbatim. Binary SAB is decoded, composed, and rewritten as text SAT
+/// (the SAB writer is not lossless for this edit). A parse failure leaves
+/// the data unchanged.
+pub(crate) fn compose_acis_placement(acis: &mut AcisData, transform: &Transform) {
+    let Some(mut doc) = acis.parse() else {
+        return;
+    };
+    let (m, t, s) = doc.placement();
+    // Existing placement as a column-vector linear map L (world = L·p + T):
+    //   world = s·(p·M) + T  ⇒  L[i][j] = s·M[j][i].
+    let mut l = [[0.0f64; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            l[i][j] = s * m[j][i];
+        }
+    }
+    // Incoming transform: rotation/scale R and translation tr (column form).
+    let mm = &transform.matrix.m;
+    let r = [
+        [mm[0][0], mm[0][1], mm[0][2]],
+        [mm[1][0], mm[1][1], mm[1][2]],
+        [mm[2][0], mm[2][1], mm[2][2]],
+    ];
+    let tr_in = [mm[0][3], mm[1][3], mm[2][3]];
+    // L' = R·L
+    let mut lp = [[0.0f64; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            lp[i][j] = r[i][0] * l[0][j] + r[i][1] * l[1][j] + r[i][2] * l[2][j];
+        }
+    }
+    // T' = R·T + tr_in
+    let tp = [
+        r[0][0] * t[0] + r[0][1] * t[1] + r[0][2] * t[2] + tr_in[0],
+        r[1][0] * t[0] + r[1][1] * t[1] + r[1][2] * t[2] + tr_in[1],
+        r[2][0] * t[0] + r[2][1] * t[1] + r[2][2] * t[2] + tr_in[2],
+    ];
+    // Re-encode with scale = 1 and M_out[r][c] = L'[c][r], so that
+    // `p·M_out` reproduces `L'·p`.
+    let m_out = [
+        [lp[0][0], lp[1][0], lp[2][0]],
+        [lp[0][1], lp[1][1], lp[2][1]],
+        [lp[0][2], lp[1][2], lp[2][2]],
+    ];
+    doc.set_placement(m_out, tp, 1.0);
+    *acis = AcisData::from_sat(&doc.to_sat_string());
+}
 
 
 /// True when `transform` reverses orientation (negative upper-3×3
@@ -498,8 +553,18 @@ pub(crate) fn transform_normal(transform: &Transform, normal: Vector3) -> Vector
 }
 
 pub(crate) fn transform_insert(e: &mut Insert, transform: &Transform) {
-    let new_position = transform.apply(e.insert_point);
     let new_normal = transform_normal(transform, e.normal);
+
+    // `insert_point` is stored in the OCS defined by `normal`, not in world
+    // space. Convert it to world, apply the transform there, then map it back
+    // into the (possibly new) OCS — otherwise a world-space move/rotate of a
+    // block whose extrusion direction isn't +Z lands on the wrong axes.
+    // For a +Z normal the OCS is the identity, so this is a no-op.
+    let ocs_old = Matrix3::arbitrary_axis(e.normal);
+    let world_pos = ocs_old * e.insert_point;
+    let new_world_pos = transform.apply(world_pos);
+    let ocs_new = Matrix3::arbitrary_axis(new_normal);
+    let new_position = ocs_new.transpose() * new_world_pos;
 
     let trans_ow =
         Matrix3::arbitrary_axis(e.normal) * Matrix3::rotation_z(e.rotation);
@@ -707,6 +772,7 @@ pub(crate) fn transform_raster_image(e: &mut RasterImage, transform: &Transform)
 
 pub(crate) fn transform_solid3d(e: &mut Solid3D, transform: &Transform) {
     e.point_of_reference = transform.apply(e.point_of_reference);
+    compose_acis_placement(&mut e.acis_data, transform);
     for wire in &mut e.wires {
         for pt in &mut wire.points {
             *pt = transform.apply(*pt);
@@ -730,6 +796,7 @@ pub(crate) fn transform_solid3d(e: &mut Solid3D, transform: &Transform) {
 
 pub(crate) fn transform_region(e: &mut Region, transform: &Transform) {
     e.point_of_reference = transform.apply(e.point_of_reference);
+    compose_acis_placement(&mut e.acis_data, transform);
     for wire in &mut e.wires {
         for pt in &mut wire.points {
             *pt = transform.apply(*pt);
@@ -741,6 +808,7 @@ pub(crate) fn transform_region(e: &mut Region, transform: &Transform) {
 
 pub(crate) fn transform_body(e: &mut Body, transform: &Transform) {
     e.point_of_reference = transform.apply(e.point_of_reference);
+    compose_acis_placement(&mut e.acis_data, transform);
     for wire in &mut e.wires {
         for pt in &mut wire.points {
             *pt = transform.apply(*pt);
@@ -749,6 +817,7 @@ pub(crate) fn transform_body(e: &mut Body, transform: &Transform) {
 }
 
 pub(crate) fn transform_surface(e: &mut crate::entities::Surface, transform: &Transform) {
+    compose_acis_placement(&mut e.acis_data, transform);
     for wire in &mut e.wires {
         for pt in &mut wire.points {
             *pt = transform.apply(*pt);

--- a/src/entities/transform.rs
+++ b/src/entities/transform.rs
@@ -107,14 +107,41 @@ pub(crate) fn transform_circle(e: &mut Circle, transform: &Transform) {
 // ── Arc ──────────────────────────────────────────────────────────────────────
 
 pub(crate) fn transform_arc(e: &mut Arc, transform: &Transform) {
-    e.center = transform.apply(e.center);
+    // The start/end angles are measured in the arc's plane, so a rotation or
+    // reflection must move them too — transform the actual endpoints and
+    // recompute the angles in the new plane. (Translating alone leaves the
+    // angles unchanged, as before.)
+    let ocs = Matrix3::arbitrary_axis(e.normal);
+    let endpoint = |ang: f64| {
+        let local = Vector3::new(e.radius * ang.cos(), e.radius * ang.sin(), 0.0);
+        e.center + ocs * local
+    };
+    let ws = transform.apply(endpoint(e.start_angle));
+    let we = transform.apply(endpoint(e.end_angle));
 
-    let unit_x = Vector3::new(1.0, 0.0, 0.0);
-    let transformed_unit = transform.apply_rotation(unit_x);
-    let scale_factor = transformed_unit.length();
+    let new_center = transform.apply(e.center);
+    let scale_factor = transform.apply_rotation(Vector3::new(1.0, 0.0, 0.0)).length();
+    let new_normal = transform.apply_rotation(e.normal).normalize();
+
+    let new_ocs_t = Matrix3::arbitrary_axis(new_normal).transpose();
+    let angle_of = |w: Vector3| {
+        let l = new_ocs_t * (w - new_center);
+        l.y.atan2(l.x)
+    };
+    let (a_start, a_end) = (angle_of(ws), angle_of(we));
+
+    // An arc is stored CCW from start→end. A reflection reverses orientation,
+    // so the reflected CCW arc traces CW — swap the endpoints to keep it CCW.
+    if is_reflecting(transform) {
+        e.start_angle = a_end;
+        e.end_angle = a_start;
+    } else {
+        e.start_angle = a_start;
+        e.end_angle = a_end;
+    }
+    e.center = new_center;
     e.radius *= scale_factor;
-
-    e.normal = transform.apply_rotation(e.normal).normalize();
+    e.normal = new_normal;
 }
 
 // ── Ellipse ──────────────────────────────────────────────────────────────────

--- a/src/entities/translate.rs
+++ b/src/entities/translate.rs
@@ -219,7 +219,12 @@ pub(crate) fn translate_face3d(e: &mut Face3D, offset: Vector3) {
 // ── Insert ───────────────────────────────────────────────────────────────────
 
 pub(crate) fn translate_insert(e: &mut Insert, offset: Vector3) {
-    e.insert_point = e.insert_point + offset;
+    // `insert_point` lives in the OCS defined by `normal`, so a world-space
+    // offset can't be added to it directly — convert to world, add, convert
+    // back. For a +Z normal the OCS is the identity and this is a plain add.
+    let ocs = Matrix3::arbitrary_axis(e.normal);
+    let world = ocs * e.insert_point + offset;
+    e.insert_point = ocs.transpose() * world;
 }
 
 // ── Block ────────────────────────────────────────────────────────────────────

--- a/src/entities/translate.rs
+++ b/src/entities/translate.rs
@@ -4,7 +4,7 @@
 //! and [`EntityType`] exposes a convenience dispatch method.
 
 use super::*;
-use crate::types::{Matrix3, Vector3};
+use crate::types::{Matrix3, Transform, Vector3};
 
 // ── Point ────────────────────────────────────────────────────────────────────
 
@@ -330,6 +330,9 @@ pub(crate) fn translate_raster_image(e: &mut RasterImage, offset: Vector3) {
 
 pub(crate) fn translate_solid3d(e: &mut Solid3D, offset: Vector3) {
     e.point_of_reference = e.point_of_reference + offset;
+    // The body geometry lives in the ACIS placement, so move it there too —
+    // otherwise the solid keeps rendering at its original location.
+    super::transform::compose_acis_placement(&mut e.acis_data, &Transform::from_translation(offset));
 
     for wire in &mut e.wires {
         for pt in &mut wire.points {
@@ -352,6 +355,7 @@ pub(crate) fn translate_solid3d(e: &mut Solid3D, offset: Vector3) {
 
 pub(crate) fn translate_region(e: &mut Region, offset: Vector3) {
     e.point_of_reference = e.point_of_reference + offset;
+    super::transform::compose_acis_placement(&mut e.acis_data, &Transform::from_translation(offset));
     for wire in &mut e.wires {
         for pt in &mut wire.points {
             *pt = *pt + offset;
@@ -363,6 +367,7 @@ pub(crate) fn translate_region(e: &mut Region, offset: Vector3) {
 
 pub(crate) fn translate_body(e: &mut Body, offset: Vector3) {
     e.point_of_reference = e.point_of_reference + offset;
+    super::transform::compose_acis_placement(&mut e.acis_data, &Transform::from_translation(offset));
     for wire in &mut e.wires {
         for pt in &mut wire.points {
             *pt = *pt + offset;
@@ -371,6 +376,7 @@ pub(crate) fn translate_body(e: &mut Body, offset: Vector3) {
 }
 
 pub(crate) fn translate_surface(e: &mut crate::entities::Surface, offset: Vector3) {
+    super::transform::compose_acis_placement(&mut e.acis_data, &Transform::from_translation(offset));
     for wire in &mut e.wires {
         for pt in &mut wire.points {
             *pt = *pt + offset;

--- a/src/entities/viewport.rs
+++ b/src/entities/viewport.rs
@@ -50,47 +50,49 @@ impl ViewportStatusFlags {
         }
     }
 
-    /// Create from DXF bit flag value
+    /// Create from the DWG/DXF viewport status bit-coded flags (group 90).
+    /// The low bits run perspective(0x1) … iso_pair_right(0x2000); the two high
+    /// bits are viewport-locked(0x4000) and viewport-on/visible(0x8000).
     pub fn from_bits(bits: i32) -> Self {
         Self {
-            is_on: (bits & (1 << 0)) != 0,
-            perspective: (bits & (1 << 1)) != 0,
-            front_clipping: (bits & (1 << 2)) != 0,
-            back_clipping: (bits & (1 << 3)) != 0,
-            ucs_follow: (bits & (1 << 4)) != 0,
-            front_clip_not_at_eye: (bits & (1 << 5)) != 0,
-            ucs_icon_visible: (bits & (1 << 6)) != 0,
-            ucs_icon_at_origin: (bits & (1 << 7)) != 0,
-            fast_zoom: (bits & (1 << 8)) != 0,
-            snap_on: (bits & (1 << 9)) != 0,
-            grid_on: (bits & (1 << 10)) != 0,
-            isometric_snap: (bits & (1 << 11)) != 0,
-            hide_plot: (bits & (1 << 12)) != 0,
-            iso_pair_top: (bits & (1 << 13)) != 0,
-            iso_pair_right: (bits & (1 << 14)) != 0,
-            locked: (bits & (1 << 15)) != 0,
+            perspective: (bits & (1 << 0)) != 0,
+            front_clipping: (bits & (1 << 1)) != 0,
+            back_clipping: (bits & (1 << 2)) != 0,
+            ucs_follow: (bits & (1 << 3)) != 0,
+            front_clip_not_at_eye: (bits & (1 << 4)) != 0,
+            ucs_icon_visible: (bits & (1 << 5)) != 0,
+            ucs_icon_at_origin: (bits & (1 << 6)) != 0,
+            fast_zoom: (bits & (1 << 7)) != 0,
+            snap_on: (bits & (1 << 8)) != 0,
+            grid_on: (bits & (1 << 9)) != 0,
+            isometric_snap: (bits & (1 << 10)) != 0,
+            hide_plot: (bits & (1 << 11)) != 0,
+            iso_pair_top: (bits & (1 << 12)) != 0,
+            iso_pair_right: (bits & (1 << 13)) != 0,
+            locked: (bits & (1 << 14)) != 0,
+            is_on: (bits & (1 << 15)) != 0,
         }
     }
 
-    /// Convert to DXF bit flag value
+    /// Convert to the DWG/DXF viewport status bit-coded flags (group 90).
     pub fn to_bits(&self) -> i32 {
         let mut bits = 0;
-        if self.is_on { bits |= 1 << 0; }
-        if self.perspective { bits |= 1 << 1; }
-        if self.front_clipping { bits |= 1 << 2; }
-        if self.back_clipping { bits |= 1 << 3; }
-        if self.ucs_follow { bits |= 1 << 4; }
-        if self.front_clip_not_at_eye { bits |= 1 << 5; }
-        if self.ucs_icon_visible { bits |= 1 << 6; }
-        if self.ucs_icon_at_origin { bits |= 1 << 7; }
-        if self.fast_zoom { bits |= 1 << 8; }
-        if self.snap_on { bits |= 1 << 9; }
-        if self.grid_on { bits |= 1 << 10; }
-        if self.isometric_snap { bits |= 1 << 11; }
-        if self.hide_plot { bits |= 1 << 12; }
-        if self.iso_pair_top { bits |= 1 << 13; }
-        if self.iso_pair_right { bits |= 1 << 14; }
-        if self.locked { bits |= 1 << 15; }
+        if self.perspective { bits |= 1 << 0; }
+        if self.front_clipping { bits |= 1 << 1; }
+        if self.back_clipping { bits |= 1 << 2; }
+        if self.ucs_follow { bits |= 1 << 3; }
+        if self.front_clip_not_at_eye { bits |= 1 << 4; }
+        if self.ucs_icon_visible { bits |= 1 << 5; }
+        if self.ucs_icon_at_origin { bits |= 1 << 6; }
+        if self.fast_zoom { bits |= 1 << 7; }
+        if self.snap_on { bits |= 1 << 8; }
+        if self.grid_on { bits |= 1 << 9; }
+        if self.isometric_snap { bits |= 1 << 10; }
+        if self.hide_plot { bits |= 1 << 11; }
+        if self.iso_pair_top { bits |= 1 << 12; }
+        if self.iso_pair_right { bits |= 1 << 13; }
+        if self.locked { bits |= 1 << 14; }
+        if self.is_on { bits |= 1 << 15; }
         bits
     }
 }
@@ -720,12 +722,19 @@ mod tests {
 
     #[test]
     fn test_viewport_status_flags() {
-        let flags = ViewportStatusFlags::from_bits(0b1000000000000001);
+        // Spec layout (group 90): bit 15 = viewport on, bit 14 = locked,
+        // bit 0 = perspective. 0x8001 = on + perspective.
+        let flags = ViewportStatusFlags::from_bits(0x8001);
         assert!(flags.is_on);
-        assert!(flags.locked);
-        assert!(!flags.perspective);
-        
-        assert_eq!(flags.to_bits(), 0b1000000000000001);
+        assert!(flags.perspective);
+        assert!(!flags.locked);
+        assert_eq!(flags.to_bits(), 0x8001);
+
+        // Locked, off viewport: bit 14 only.
+        let locked = ViewportStatusFlags::from_bits(0x4000);
+        assert!(locked.locked);
+        assert!(!locked.is_on);
+        assert_eq!(locked.to_bits(), 0x4000);
     }
 
     #[test]

--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -2132,6 +2132,33 @@ impl DwgDocumentBuilder {
                     obj.paper_width   = data.plot_settings.paper_width;
                     obj.paper_height  = data.plot_settings.paper_height;
                     obj.plot_rotation = data.plot_settings.rotation;
+                    let ps = &data.plot_settings;
+                    obj.plot_page_name = ps.page_name.clone();
+                    obj.plot_printer_name = ps.printer_name.clone();
+                    obj.paper_size = ps.paper_size.clone();
+                    obj.plot_view_name = ps.plot_view_name.clone();
+                    obj.plot_style_sheet = ps.current_style_sheet.clone();
+                    obj.plot_margin_left = ps.left_margin;
+                    obj.plot_margin_bottom = ps.bottom_margin;
+                    obj.plot_margin_right = ps.right_margin;
+                    obj.plot_margin_top = ps.top_margin;
+                    obj.plot_origin_x = ps.origin_x;
+                    obj.plot_origin_y = ps.origin_y;
+                    obj.plot_window_min_x = ps.window_min_x;
+                    obj.plot_window_min_y = ps.window_min_y;
+                    obj.plot_window_max_x = ps.window_max_x;
+                    obj.plot_window_max_y = ps.window_max_y;
+                    obj.plot_paper_units = ps.paper_units;
+                    obj.plot_type = ps.plot_type;
+                    obj.plot_scale_numerator = ps.scale_numerator;
+                    obj.plot_scale_denominator = ps.scale_denominator;
+                    obj.plot_scale_type = ps.scale_type;
+                    obj.plot_scale_factor = ps.scale_factor;
+                    obj.paper_image_origin_x = ps.paper_image_x;
+                    obj.paper_image_origin_y = ps.paper_image_y;
+                    obj.shade_plot_mode = ps.shade_plot_mode;
+                    obj.shade_plot_resolution = ps.shade_plot_resolution;
+                    obj.shade_plot_dpi = ps.shade_plot_dpi;
                     document.objects.insert(
                         Handle::from(handle),
                         crate::objects::ObjectType::Layout(obj),

--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -1904,7 +1904,6 @@ impl DwgDocumentBuilder {
                     );
                     let mut e = Solid3D::new();
                     e.common = entity_common;
-                    e.point_of_reference = data.point;
                     e.acis_data.version = if data.is_binary {
                         crate::entities::solid3d::AcisVersion::Version2
                     } else {
@@ -1913,6 +1912,11 @@ impl DwgDocumentBuilder {
                     e.acis_data.sat_data = data.sat_data;
                     e.acis_data.sab_data = data.sab_data;
                     e.acis_data.is_binary = data.is_binary;
+                    // A 3D solid has no insertion point of its own; the file's
+                    // point field is usually zero. Prefer the ACIS placement
+                    // origin so the reference reflects where the body sits.
+                    e.point_of_reference =
+                        e.acis_data.placement_origin().unwrap_or(data.point);
                     e.wires = data.wires;
                     e.silhouettes = data.silhouettes;
 
@@ -1933,7 +1937,6 @@ impl DwgDocumentBuilder {
                     );
                     let mut e = Region::new();
                     e.common = entity_common;
-                    e.point_of_reference = data.point;
                     e.acis_data.version = if data.is_binary {
                         crate::entities::solid3d::AcisVersion::Version2
                     } else {
@@ -1942,6 +1945,8 @@ impl DwgDocumentBuilder {
                     e.acis_data.sat_data = data.sat_data;
                     e.acis_data.sab_data = data.sab_data;
                     e.acis_data.is_binary = data.is_binary;
+                    e.point_of_reference =
+                        e.acis_data.placement_origin().unwrap_or(data.point);
                     e.wires = data.wires;
                     e.silhouettes = data.silhouettes;
                     let _ = document.add_entity(EntityType::Region(e));
@@ -1952,7 +1957,6 @@ impl DwgDocumentBuilder {
                     );
                     let mut e = Body::new();
                     e.common = entity_common;
-                    e.point_of_reference = data.point;
                     e.acis_data.version = if data.is_binary {
                         crate::entities::solid3d::AcisVersion::Version2
                     } else {
@@ -1961,6 +1965,8 @@ impl DwgDocumentBuilder {
                     e.acis_data.sat_data = data.sat_data;
                     e.acis_data.sab_data = data.sab_data;
                     e.acis_data.is_binary = data.is_binary;
+                    e.point_of_reference =
+                        e.acis_data.placement_origin().unwrap_or(data.point);
                     e.wires = data.wires;
                     e.silhouettes = data.silhouettes;
                     let _ = document.add_entity(EntityType::Body(e));

--- a/src/io/dwg/dwg_reader.rs
+++ b/src/io/dwg/dwg_reader.rs
@@ -223,23 +223,49 @@ fn attach_acds_sab_blobs(document: &mut crate::document::CadDocument, blobs: Vec
 
     let mut it = blobs.into_iter();
     let mut attached = 0usize;
+    // Fill an AcisData from the next blob; returns false when the iterator is
+    // exhausted (so the caller breaks).
+    fn fill(acis: &mut crate::entities::solid3d::AcisData, blob: Vec<u8>) {
+        acis.sab_data = blob;
+        acis.sat_data = String::new();
+        acis.is_binary = true;
+        acis.version = AcisVersion::Version2;
+    }
     for entity in document.entities_mut() {
-        let acis = match entity {
-            EntityType::Solid3D(s) => &mut s.acis_data,
-            EntityType::Region(r) => &mut r.acis_data,
-            EntityType::Body(b) => &mut b.acis_data,
-            EntityType::Surface(s) => &mut s.acis_data,
-            _ => continue,
-        };
-        match it.next() {
-            Some(blob) => {
-                acis.sab_data = blob;
-                acis.sat_data = String::new();
-                acis.is_binary = true;
-                acis.version = AcisVersion::Version2;
+        // Only consume a blob for ACIS-backed entities, in document order.
+        match entity {
+            EntityType::Solid3D(s) => {
+                let Some(blob) = it.next() else { break };
+                fill(&mut s.acis_data, blob);
+                // The SAB geometry — and with it the body's placement — only
+                // becomes available now, so derive the reference point here.
+                if let Some(p) = s.acis_data.placement_origin() {
+                    s.point_of_reference = p;
+                }
                 attached += 1;
             }
-            None => break,
+            EntityType::Region(r) => {
+                let Some(blob) = it.next() else { break };
+                fill(&mut r.acis_data, blob);
+                if let Some(p) = r.acis_data.placement_origin() {
+                    r.point_of_reference = p;
+                }
+                attached += 1;
+            }
+            EntityType::Body(b) => {
+                let Some(blob) = it.next() else { break };
+                fill(&mut b.acis_data, blob);
+                if let Some(p) = b.acis_data.placement_origin() {
+                    b.point_of_reference = p;
+                }
+                attached += 1;
+            }
+            EntityType::Surface(s) => {
+                let Some(blob) = it.next() else { break };
+                fill(&mut s.acis_data, blob);
+                attached += 1;
+            }
+            _ => continue,
         }
     }
     attached

--- a/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
@@ -1463,13 +1463,31 @@ impl<'a> DwgObjectWriter<'a> {
             .collect();
 
         for br in &block_records {
-            // Use original entity_handles from the DWG binary when available
-            // (preserves sub-entity handles exactly). Fall back to expanding
-            // from the document model for programmatically created blocks.
-            let entity_handles_for_header = self.document.block_entity_handles
-                .get(&br.handle)
-                .cloned()
-                .unwrap_or_else(|| self.expand_entity_handles(&br.entity_handles));
+            // The block header's owned-handle list MUST match the objects the
+            // entity loop below actually writes (br.entity_handles + their
+            // sub-entities). Compute that set first.
+            let expanded = self.expand_entity_handles(&br.entity_handles);
+            // Prefer the original DWG-binary order/handles when available, but
+            // only when they describe exactly the same set — otherwise the file
+            // had entities added or removed since it was read and the stored
+            // list is stale, leaving the header pointing at handles that are
+            // never written. AutoCAD stops reading a block's contents at the
+            // first such dangling owned handle, silently dropping every entity
+            // after it. Drop stale entries and fall back to the live set.
+            let entity_handles_for_header = match self.document.block_entity_handles.get(&br.handle) {
+                Some(orig) => {
+                    use std::collections::HashSet;
+                    let valid: HashSet<u64> = expanded.iter().map(|h| h.value()).collect();
+                    let filtered: Vec<Handle> =
+                        orig.iter().copied().filter(|h| valid.contains(&h.value())).collect();
+                    if filtered.len() == expanded.len() {
+                        filtered
+                    } else {
+                        expanded
+                    }
+                }
+                None => expanded,
+            };
             self.write_block_header_with_handles(br, &entity_handles_for_header);
             self.write_block_begin(br);
 

--- a/src/io/dwg/dwg_stream_writers/object_writer/objects.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/objects.rs
@@ -269,7 +269,7 @@ impl<'a> DwgObjectWriter<'a> {
         // ── PlotSettings preamble ──
         // ModelType flag (bit 0x400) must be set for model space layouts
         let plot_flags: i16 = if layout.name == "Model" { 0x400 } else { 0 };
-        self.write_plot_settings_data(plot_flags);
+        self.write_plot_settings_data(plot_flags, layout);
 
         // ── Layout-specific data ──
         // Layout name (TV)
@@ -358,70 +358,82 @@ impl<'a> DwgObjectWriter<'a> {
     ///
     /// Field order must match C# DwgObjectWriter.Objects.cs writePlotSettings()
     /// exactly. Uses simplified/default values.
-    fn write_plot_settings_data(&mut self, plot_flags: i16) {
+    fn write_plot_settings_data(&mut self, plot_flags: i16, layout: &crate::objects::Layout) {
+        // Fall back to A4 landscape when the layout carries no paper size
+        // (e.g. freshly created layouts that never read a PlotSettings block).
+        let (paper_width, paper_height) =
+            if layout.paper_width > 0.0 && layout.paper_height > 0.0 {
+                (layout.paper_width, layout.paper_height)
+            } else {
+                (297.0, 210.0)
+            };
         // Page setup name (TV 1)
-        self.writer.write_variable_text("");
+        self.writer.write_variable_text(&layout.plot_page_name);
         // Printer / Config (TV 2)
-        self.writer.write_variable_text("");
+        self.writer.write_variable_text(&layout.plot_printer_name);
         // Plot layout flags (BS 70)
         self.writer.write_bit_short(plot_flags);
 
         // Margins (BD: left, bottom, right, top)
-        self.writer.write_bit_double(0.0);
-        self.writer.write_bit_double(0.0);
-        self.writer.write_bit_double(0.0);
-        self.writer.write_bit_double(0.0);
+        self.writer.write_bit_double(layout.plot_margin_left);
+        self.writer.write_bit_double(layout.plot_margin_bottom);
+        self.writer.write_bit_double(layout.plot_margin_right);
+        self.writer.write_bit_double(layout.plot_margin_top);
 
         // Paper width (BD 44), height (BD 45)
-        self.writer.write_bit_double(297.0);
-        self.writer.write_bit_double(210.0);
+        self.writer.write_bit_double(paper_width);
+        self.writer.write_bit_double(paper_height);
 
         // Paper size (TV 4)
-        self.writer.write_variable_text("");
+        self.writer.write_variable_text(&layout.paper_size);
 
         // Plot origin (2BD 46,47)
-        self.writer.write_bit_double(0.0);
-        self.writer.write_bit_double(0.0);
+        self.writer.write_bit_double(layout.plot_origin_x);
+        self.writer.write_bit_double(layout.plot_origin_y);
 
         // Paper units (BS 72), Plot rotation (BS 73), Plot type (BS 74)
-        self.writer.write_bit_short(0); // paper units
-        self.writer.write_bit_short(0); // rotation
-        self.writer.write_bit_short(5); // type: Layout
+        self.writer.write_bit_short(layout.plot_paper_units);
+        self.writer.write_bit_short(layout.plot_rotation);
+        self.writer.write_bit_short(layout.plot_type);
 
         // Plot window (2BD min, 2BD max)
-        self.writer.write_bit_double(0.0);
-        self.writer.write_bit_double(0.0);
-        self.writer.write_bit_double(0.0);
-        self.writer.write_bit_double(0.0);
+        self.writer.write_bit_double(layout.plot_window_min_x);
+        self.writer.write_bit_double(layout.plot_window_min_y);
+        self.writer.write_bit_double(layout.plot_window_max_x);
+        self.writer.write_bit_double(layout.plot_window_max_y);
 
         // R13-R2000 only: Plot view name (TV 6)
         if self.version.r13_15_only() {
-            self.writer.write_variable_text("");
+            self.writer.write_variable_text(&layout.plot_view_name);
         }
 
         // Real world units / numerator (BD 142)
-        self.writer.write_bit_double(1.0);
+        let num = if layout.plot_scale_numerator != 0.0 { layout.plot_scale_numerator } else { 1.0 };
+        let den = if layout.plot_scale_denominator != 0.0 { layout.plot_scale_denominator } else { 1.0 };
+        self.writer.write_bit_double(num);
         // Drawing units / denominator (BD 143)
-        self.writer.write_bit_double(1.0);
+        self.writer.write_bit_double(den);
 
         // Current style sheet (TV 7)
-        self.writer.write_variable_text("");
+        self.writer.write_variable_text(&layout.plot_style_sheet);
 
         // Scale type (BS 75)
-        self.writer.write_bit_short(0);
+        self.writer.write_bit_short(layout.plot_scale_type);
 
         // Scale factor (BD 147) — standard scale value
-        self.writer.write_bit_double(1.0);
+        let factor = if layout.plot_scale_factor != 0.0 { layout.plot_scale_factor } else { 1.0 };
+        self.writer.write_bit_double(factor);
 
         // Paper image origin (2BD 148,149)
-        self.writer.write_bit_double(0.0);
-        self.writer.write_bit_double(0.0);
+        self.writer.write_bit_double(layout.paper_image_origin_x);
+        self.writer.write_bit_double(layout.paper_image_origin_y);
 
         // R2004+: shade plot fields
         if self.version.r2004_plus() {
-            self.writer.write_bit_short(0);   // shade plot mode (BS 76)
-            self.writer.write_bit_short(0);   // shade plot res level (BS 77)
-            self.writer.write_bit_short(300); // shade plot DPI (BS 78)
+            self.writer.write_bit_short(layout.shade_plot_mode);
+            self.writer.write_bit_short(layout.shade_plot_resolution);
+            let dpi = if layout.shade_plot_dpi != 0 { layout.shade_plot_dpi } else { 300 };
+            self.writer.write_bit_short(dpi);
 
             // Plot view handle (hard pointer)
             self.writer

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -166,6 +166,41 @@ pub struct Layout {
     pub paper_height: f64,
     /// Plot rotation from PlotSettings (code 73): 0=none, 1=90°, 2=180°, 3=270°.
     pub plot_rotation: i16,
+
+    // ── Remaining embedded PlotSettings fields ──────────────────────────────
+    // The LAYOUT object embeds a full PlotSettings record. Preserving only the
+    // paper size left the sheet unsized in AutoCAD (rendered tiny in the corner
+    // because the paper-size name / units / margins were dropped). Keep the rest
+    // so the layout round-trips faithfully. See issue #156.
+    pub plot_page_name: String,
+    pub plot_printer_name: String,
+    /// Paper-size name (e.g. "ISO_A4_(210.00_x_297.00_MM)"). AutoCAD renders the
+    /// sheet from this; an empty name shows no/wrong paper.
+    pub paper_size: String,
+    pub plot_view_name: String,
+    pub plot_style_sheet: String,
+    pub plot_margin_left: f64,
+    pub plot_margin_bottom: f64,
+    pub plot_margin_right: f64,
+    pub plot_margin_top: f64,
+    pub plot_origin_x: f64,
+    pub plot_origin_y: f64,
+    pub plot_window_min_x: f64,
+    pub plot_window_min_y: f64,
+    pub plot_window_max_x: f64,
+    pub plot_window_max_y: f64,
+    /// Paper units (code 72): 0=inches, 1=mm, 2=pixels.
+    pub plot_paper_units: i16,
+    pub plot_type: i16,
+    pub plot_scale_numerator: f64,
+    pub plot_scale_denominator: f64,
+    pub plot_scale_type: i16,
+    pub plot_scale_factor: f64,
+    pub paper_image_origin_x: f64,
+    pub paper_image_origin_y: f64,
+    pub shade_plot_mode: i16,
+    pub shade_plot_resolution: i16,
+    pub shade_plot_dpi: i16,
 }
 
 impl Layout {
@@ -195,6 +230,32 @@ impl Layout {
             paper_width: 0.0,
             paper_height: 0.0,
             plot_rotation: 0,
+            plot_page_name: String::new(),
+            plot_printer_name: String::new(),
+            paper_size: String::new(),
+            plot_view_name: String::new(),
+            plot_style_sheet: String::new(),
+            plot_margin_left: 0.0,
+            plot_margin_bottom: 0.0,
+            plot_margin_right: 0.0,
+            plot_margin_top: 0.0,
+            plot_origin_x: 0.0,
+            plot_origin_y: 0.0,
+            plot_window_min_x: 0.0,
+            plot_window_min_y: 0.0,
+            plot_window_max_x: 0.0,
+            plot_window_max_y: 0.0,
+            plot_paper_units: 0,
+            plot_type: 5,
+            plot_scale_numerator: 1.0,
+            plot_scale_denominator: 1.0,
+            plot_scale_type: 0,
+            plot_scale_factor: 1.0,
+            paper_image_origin_x: 0.0,
+            paper_image_origin_y: 0.0,
+            shade_plot_mode: 0,
+            shade_plot_resolution: 0,
+            shade_plot_dpi: 300,
         }
     }
 }


### PR DESCRIPTION
A batch of DWG read/write correctness fixes plus ACIS loop and transform fixes.

## DWG round-trip
- **Viewport status flags** are now written in the spec bit layout. `is_on` sat at bit 0 and `locked` at bit 15, shifting every flag one place off the group-90 spec (perspective…iso at 0x1…0x2000, locked at 0x4000, viewport-on at 0x8000). Re-saving flipped the on/off and locked state, so AutoCAD read a paper-space overall viewport as off and crashed on layout activation.
- **Layout PlotSettings preserved.** The LAYOUT writer hard-coded the paper size to 297×210 and defaulted the paper name, units, margins, origin and scale, so re-saving any layout reset its page setup — AutoCAD then rendered the sheet tiny in the corner (empty paper-size name, units forced to inches). The full embedded PlotSettings now round-trips.
- **Block header owned-handle list kept in sync** with the entities actually written. The list was taken from the raw read-time capture and never updated on add/remove, so after an edit the header listed handles that are no longer written — dangling owned references. AutoCAD stops reading a block's contents at the first dangling owned handle and silently drops every entity after it (model-space geometry vanished while the file still opened elsewhere). The list is filtered against the live written set, falling back to it when stale.

## ACIS / SAB
- Read `SatLoop` `next_loop` from the correct token (token 1, not 0) so a face's inner (hole) loops chain and pierced faces aren't read as solid.
- Correct the `SatLoop` record-layout comment.
- Transform body geometry and derive solid reference points; move solid geometry on translate, not just the reference point.

## Transform
- Rotate/reflect an arc's start and end angles.
