### PR TITLE
fix(dwg): VPort zoom-extents twist-awareness + SORTENTSTABLE stream layout

### DIFF
--- a/src/io/dwg/dwg_stream_readers/merged_reader.rs
+++ b/src/io/dwg/dwg_stream_readers/merged_reader.rs
@@ -299,6 +299,14 @@ impl DwgMergedReader {
         }
     }
 
+    /// Read a handle reference from the MAIN (data) stream, even when a
+    /// separate handle stream exists. A few objects store some handle
+    /// references inline in the data section rather than in the handle stream
+    /// — e.g. the SORTENTSTABLE sort handles. (#146)
+    pub fn read_main_handle(&mut self) -> u64 {
+        self.main.read_handle_relative(self.ref_handle)
+    }
+
     /// Set the reference handle for offset-based handle codes.
     ///
     /// Must be called after reading the current object's own handle

--- a/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/objects.rs
@@ -677,13 +677,25 @@ pub fn read_scale(reader: &mut DwgMergedReader) -> ScaleData {
 
 pub fn read_sort_entities_table(reader: &mut DwgMergedReader) -> SortEntitiesTableData {
     let num_entries = safe_count(reader.read_bit_long());
-    let mut entries = Vec::with_capacity(num_entries as usize);
+    // The per-entry sort handles are stored inline in the DATA section; the
+    // owner block and the sorted entity handles follow in the handle stream
+    // (owner first, then one handle per entry). The previous code read a
+    // sort+entity pair per entry from the handle stream and the owner last,
+    // which scrambled the order and the owner block on files written by other
+    // CAD apps — draw order was effectively ignored. (#146)
+    let mut sort_handles = Vec::with_capacity(num_entries as usize);
     for _ in 0..num_entries {
-        let sort_handle = reader.read_handle();
-        let entity_handle = reader.read_handle();
-        entries.push(SortEntitiesEntry { sort_handle, entity_handle });
+        sort_handles.push(reader.read_main_handle());
     }
     let block_owner_handle = reader.read_handle();
+    let mut entries = Vec::with_capacity(num_entries as usize);
+    for k in 0..num_entries as usize {
+        let entity_handle = reader.read_handle();
+        entries.push(SortEntitiesEntry {
+            sort_handle: sort_handles[k],
+            entity_handle,
+        });
+    }
     SortEntitiesTableData { entries, block_owner_handle }
 }
 
@@ -1095,12 +1107,16 @@ mod tests {
         let d = DxfVersion::AC1015;
         let mut r = make_reader(v, d, |w| {
             w.write_bit_long(1); // 1 entry
-            w.write_handle(DwgReferenceType::SoftPointer, 0x10);
-            w.write_handle(DwgReferenceType::HardPointer, 0x20);
+            // Layout: sort handles in the DATA section, then owner + entities in
+            // the handle stream.
+            w.write_main_handle(DwgReferenceType::SoftPointer, 0x10); // sort (data)
             w.write_handle(DwgReferenceType::HardPointer, 0x30); // block owner
+            w.write_handle(DwgReferenceType::SoftPointer, 0x20); // entity handle
         });
         let st = read_sort_entities_table(&mut r);
         assert_eq!(st.entries.len(), 1);
         assert_eq!(st.block_owner_handle, 0x30);
+        assert_eq!(st.entries[0].sort_handle, 0x10);
+        assert_eq!(st.entries[0].entity_handle, 0x20);
     }
 }

--- a/src/io/dwg/dwg_stream_writers/merged_writer.rs
+++ b/src/io/dwg/dwg_stream_writers/merged_writer.rs
@@ -331,6 +331,14 @@ impl DwgMergedWriter {
         self.handle.write_handle(ref_type, handle);
     }
 
+    /// Write a handle reference into the MAIN (data) stream, for objects that
+    /// store some handle refs inline in the data section rather than the handle
+    /// stream — e.g. the SORTENTSTABLE sort handles. Symmetric with the
+    /// reader's `read_main_handle`. (#146)
+    pub fn write_main_handle(&mut self, ref_type: DwgReferenceType, handle: u64) {
+        self.main.write_handle(ref_type, handle);
+    }
+
     /// Write an undefined-type handle reference.
     pub fn write_handle_undefined(&mut self, handle: u64) {
         self.handle.write_handle_undefined(handle);

--- a/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
@@ -866,8 +866,16 @@ impl<'a> DwgObjectWriter<'a> {
                     // the same camera.
                     let half_h = vp.view_height.abs() / 2.0;
                     let half_w = half_h * ar;
-                    let cx = vp.view_target.x + vp.view_center.x;
-                    let cy = vp.view_target.y + vp.view_center.y;
+                    // view_center is in DCS — the view plane rotated by the
+                    // view twist. The WCS center is view_target plus the
+                    // center rotated back by the twist (Rz(-twist)); using the
+                    // raw view_center here would misjudge any twisted view as
+                    // "missing" the geometry and then clobber it.
+                    let (sin_t, cos_t) = vp.view_twist.sin_cos();
+                    let cx = vp.view_target.x + cos_t * vp.view_center.x
+                        + sin_t * vp.view_center.y;
+                    let cy = vp.view_target.y - sin_t * vp.view_center.x
+                        + cos_t * vp.view_center.y;
                     let overlaps = cx + half_w >= ext.min.x
                         && cx - half_w <= ext.max.x
                         && cy + half_h >= ext.min.y
@@ -876,10 +884,15 @@ impl<'a> DwgObjectWriter<'a> {
                         // Ensure the full extents fit, with 10% margin.
                         let vh = (ext_height.max(ext_width / ar)) * 1.1;
                         vp.view_height = if vh > 0.0 { vh } else { 10.0 };
-                        // view_center is in DCS, whose origin = view_target.
-                        // Keep view_target at its default (origin) so
-                        // view_center acts as the WCS center directly.
-                        vp.view_center = Vector2::new(center.x, center.y);
+                        // Store the WCS extents center back in DCS: keep
+                        // view_target at the origin and rotate the center by
+                        // the twist (Rz(+twist)) so the reader folds it back to
+                        // the WCS center instead of double-rotating it.
+                        vp.view_target = crate::types::Vector3::ZERO;
+                        vp.view_center = Vector2::new(
+                            cos_t * center.x - sin_t * center.y,
+                            sin_t * center.x + cos_t * center.y,
+                        );
                     }
                 }
             }

--- a/src/io/dwg/dwg_stream_writers/object_writer/objects.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/objects.rs
@@ -850,16 +850,20 @@ impl<'a> DwgObjectWriter<'a> {
         let entries: Vec<_> = table.entries().collect();
         self.writer.write_bit_long(entries.len() as i32);
 
+        // Sort handles are stored inline in the DATA section (one per entry);
+        // the owner block and the sorted entity handles follow in the handle
+        // stream (owner first, then one per entry). Mirrors `read_sort_entities_
+        // table`. (#146)
         for entry in &entries {
             self.writer
-                .write_handle(DwgReferenceType::SoftPointer, entry.sort_handle.value());
-            self.writer
-                .write_handle(DwgReferenceType::HardPointer, entry.entity_handle.value());
+                .write_main_handle(DwgReferenceType::SoftPointer, entry.sort_handle.value());
         }
-
-        // Block owner handle
         self.writer
             .write_handle(DwgReferenceType::HardPointer, table.block_owner_handle.value());
+        for entry in &entries {
+            self.writer
+                .write_handle(DwgReferenceType::SoftPointer, entry.entity_handle.value());
+        }
 
         self.register_object(table.handle);
     }


### PR DESCRIPTION
Two DWG round-trip fixes, found while testing real survey/draw-order files in a downstream app.

## 1. `fix(dwg): make VPort zoom-extents safety net twist-aware`
The VPort writer's "zoom extents" fallback treated `view_center` as a WCS point (`cx = view_target + view_center`). For a **twisted** view, `view_center` is in DCS (the twist-rotated view plane), so this misjudged a valid saved view as missing the geometry and overwrote `view_center` with the WCS extents centre while leaving `view_twist` set. The reader then folded that WCS value through the twist again, rotating the camera about the origin — catastrophic at survey coordinates (camera flung millions of units away).

Now the overlap test computes the real WCS centre with the twist (`view_target + Rz(-twist)·view_center`), and when the fallback must replace the view it stores the centre back in DCS (`Rz(+twist)·centre`) so the reader decodes it to the intended WCS centre.

## 2. `fix(dwg): read/write SORTENTSTABLE in the correct stream layout`
The SORTENTSTABLE reader assumed each entry was a `(sort, entity)` handle pair in the handle stream followed by the owner block last. The real layout is: the per-entry **sort handles live inline in the DATA section**, then the **owner block and the entity handles** (owner first, one per entry) **in the handle stream**. The old order read the owner as `0` and scrambled the entity handles, so a consumer saw a garbage draw-order table and fell back to handle order — i.e. draw order set in other CAD apps was effectively ignored.

Adds `DwgMergedReader::read_main_handle` / `DwgMergedWriter::write_main_handle` (data-stream handles) and reads/writes the table in the correct order. Round-trips a real BricsCAD draw-order file (block owner + order preserved); round-trip unit test updated.

Both verified against real `.dwg` files (UTM survey drawing; BricsCAD line-behind-hatch draw order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)