### PR TITLE
DWG/MTEXT/ACIS fixes: xref, spline, ENC, AcDs perf + MTEXT escape codes

### DIFF
--- a/src/entities/acis/types.rs
+++ b/src/entities/acis/types.rs
@@ -1393,12 +1393,27 @@ impl SatDocument {
     }
 
     /// Returns a record by index.
+    ///
+    /// Records are parsed and appended in index order, so slot `index` almost
+    /// always holds the record whose `.index == index` — an O(1) hit. Only a
+    /// document whose records were re-ordered or hand-built falls back to the
+    /// linear scan. Tessellation resolves O(records) pointers per solid, so the
+    /// old unconditional scan made every solid O(records²) — the dominant cost
+    /// of meshing an ACIS-heavy drawing.
     pub fn record(&self, index: usize) -> Option<&SatRecord> {
+        if let Some(r) = self.records.get(index) {
+            if r.index == index as i32 {
+                return Some(r);
+            }
+        }
         self.records.iter().find(|r| r.index == index as i32)
     }
 
     /// Returns a mutable record by index.
     pub fn record_mut(&mut self, index: usize) -> Option<&mut SatRecord> {
+        if matches!(self.records.get(index), Some(r) if r.index == index as i32) {
+            return self.records.get_mut(index);
+        }
         self.records.iter_mut().find(|r| r.index == index as i32)
     }
 

--- a/src/entities/mtext_format/mod.rs
+++ b/src/entities/mtext_format/mod.rs
@@ -100,6 +100,6 @@ pub use parser::parse_mtext;
 pub use parser::parse_plain_text;
 pub use types::{
     MTextColor, MTextDocument, MTextFont, MTextLineAlignment, MTextLineSpacing, MTextParagraph,
-    MTextParagraphAlignment, MTextSpan, MTextStroke, ParagraphProperties, SpanProperties,
-    SpecialChar, StackingData, StackingType, TabStop,
+    MTextParagraphAlignment, MTextScalar, MTextSpan, MTextStroke, ParagraphProperties,
+    SpanProperties, SpecialChar, StackingData, StackingType, TabStop,
 };

--- a/src/entities/mtext_format/parser.rs
+++ b/src/entities/mtext_format/parser.rs
@@ -252,6 +252,30 @@ impl MTextParser {
                 '%' => {
                     self.handle_special_char();
                 }
+                '^' => {
+                    // Caret-encoded controls: `^I` tab, `^J` line break,
+                    // `^M` carriage return (ignored). Anything else is a
+                    // literal caret.
+                    match self.chars.get(self.pos + 1).copied() {
+                        Some('I') => {
+                            self.text_buf.push('\t');
+                            self.pos += 2;
+                        }
+                        Some('J') => {
+                            self.pos += 2;
+                            self.flush_current_span(merge_spans);
+                            self.document
+                                .push_paragraph(std::mem::take(&mut self.current_paragraph));
+                        }
+                        Some('M') => {
+                            self.pos += 2;
+                        }
+                        _ => {
+                            self.text_buf.push('^');
+                            self.pos += 1;
+                        }
+                    }
+                }
                 _ => {
                     self.text_buf.push(ch);
                     self.pos += 1;
@@ -353,6 +377,12 @@ impl MTextParser {
             }
             '}' => {
                 self.text_buf.push('}');
+                self.pos += 1;
+            }
+            // Escaped semicolon → literal `;` (so a `;` can appear in text
+            // without terminating a control code).
+            ';' => {
+                self.text_buf.push(';');
                 self.pos += 1;
             }
 
@@ -1320,6 +1350,21 @@ mod tests {
             parse_plain_text("%%176").paragraphs[0].to_plain_text(),
             "°"
         );
+    }
+
+    #[test]
+    fn test_mtext_escaped_semicolon() {
+        // `\;` is a literal semicolon, not a code terminator.
+        let doc = parse_mtext(r"a\;b", false);
+        assert_eq!(doc.to_plain_text(), "a;b");
+    }
+
+    #[test]
+    fn test_mtext_caret_codes() {
+        // `^I` → tab, `^J` → line break (new paragraph), `^M` → ignored.
+        assert!(parse_mtext("a^Ib", false).to_plain_text().contains('\t'));
+        assert_eq!(parse_mtext("a^Jb", false).paragraphs.len(), 2);
+        assert_eq!(parse_mtext("a^Mb", false).to_plain_text(), "ab");
     }
 
     // ========================================================================

--- a/src/entities/mtext_format/parser.rs
+++ b/src/entities/mtext_format/parser.rs
@@ -593,12 +593,19 @@ impl MTextParser {
         };
 
         if let Ok(f) = num_str.trim().parse::<f64>() {
-            if is_relative {
-                let cur = self.current_props().height.unwrap_or(1.0);
-                self.current_props_mut().height = Some(cur * f.abs());
+            // Relative multiplies the current height, preserving whether that
+            // current height is a factor or an absolute value; a fresh relative
+            // is a factor over the implicit 1.0. Absolute always resets.
+            let scalar = if is_relative {
+                match self.current_props().height {
+                    Some(MTextScalar::Absolute(c)) => MTextScalar::Absolute(c * f.abs()),
+                    Some(MTextScalar::Factor(c)) => MTextScalar::Factor(c * f.abs()),
+                    None => MTextScalar::Factor(f.abs()),
+                }
             } else {
-                self.current_props_mut().height = Some(f.abs());
-            }
+                MTextScalar::Absolute(f.abs())
+            };
+            self.current_props_mut().height = Some(scalar);
         }
     }
 
@@ -1211,13 +1218,19 @@ mod tests {
     #[test]
     fn test_parse_height_absolute() {
         let doc = parse_mtext(r"{\H2;Big}", false);
-        assert_eq!(doc.paragraphs[0].spans[0].properties.height, Some(2.0));
+        assert_eq!(
+            doc.paragraphs[0].spans[0].properties.height,
+            Some(MTextScalar::Absolute(2.0))
+        );
     }
 
     #[test]
     fn test_parse_height_relative() {
         let doc = parse_mtext(r"{\H2x;Bigger}", false);
-        assert_eq!(doc.paragraphs[0].spans[0].properties.height, Some(2.0));
+        assert_eq!(
+            doc.paragraphs[0].spans[0].properties.height,
+            Some(MTextScalar::Factor(2.0))
+        );
     }
 
     // ========================================================================
@@ -1520,9 +1533,18 @@ mod tests {
         // Height set in outer group should be inherited
         let doc = parse_mtext("{\\H2;Normal{\\C1;Colored}Back}", false);
         // Normal has H2, Colored has H2+C1, Back has H2
-        assert_eq!(doc.paragraphs[0].spans[0].properties.height, Some(2.0));
-        assert_eq!(doc.paragraphs[0].spans[1].properties.height, Some(2.0));
-        assert_eq!(doc.paragraphs[0].spans[2].properties.height, Some(2.0));
+        assert_eq!(
+            doc.paragraphs[0].spans[0].properties.height,
+            Some(MTextScalar::Absolute(2.0))
+        );
+        assert_eq!(
+            doc.paragraphs[0].spans[1].properties.height,
+            Some(MTextScalar::Absolute(2.0))
+        );
+        assert_eq!(
+            doc.paragraphs[0].spans[2].properties.height,
+            Some(MTextScalar::Absolute(2.0))
+        );
     }
 
     // ========================================================================
@@ -1864,8 +1886,14 @@ mod tests {
     fn test_height_carries_across_paragraphs() {
         let doc = parse_mtext("{\\H2;Tall\\PStill tall}", false);
         assert_eq!(doc.paragraphs.len(), 2);
-        assert_eq!(doc.paragraphs[0].spans[0].properties.height, Some(2.0));
-        assert_eq!(doc.paragraphs[1].spans[0].properties.height, Some(2.0));
+        assert_eq!(
+            doc.paragraphs[0].spans[0].properties.height,
+            Some(MTextScalar::Absolute(2.0))
+        );
+        assert_eq!(
+            doc.paragraphs[1].spans[0].properties.height,
+            Some(MTextScalar::Absolute(2.0))
+        );
     }
 
     #[test]

--- a/src/entities/mtext_format/parser.rs
+++ b/src/entities/mtext_format/parser.rs
@@ -109,49 +109,104 @@ impl MTextParser {
         if self.chars.is_empty() {
             return;
         }
+        // TEXT entities: backslash is literal (no MTEXT `\` codes); only `%%`
+        // control codes apply. `%%u`/`%%o` toggle underline/overline (each toggle
+        // starts a new span), `%%d`/`%%p`/`%%c` and `%%%%` resolve to symbols,
+        // `%%nnn` is a decimal character code, and `\P`/`\p` break paragraphs.
+        // Underscoring/overscoring turn off automatically at the string end.
+        let flush = |para: &mut MTextParagraph, text: &mut String, u: bool, o: bool| {
+            if text.is_empty() {
+                return;
+            }
+            let mut props = SpanProperties::default();
+            props.set_underline(u);
+            props.set_overline(o);
+            para.push_span(MTextSpan::new(std::mem::take(text), props));
+        };
+
+        let n = self.chars.len();
+        let mut para = MTextParagraph::new();
         let mut text = String::new();
-        while self.pos < self.chars.len() {
-            // Handle %% special chars
-            if self.chars[self.pos] == '%'
-                && self.pos + 2 < self.chars.len()
-                && self.chars[self.pos + 1] == '%'
-            {
-                self.pos += 2;
-                let code = self.chars[self.pos].to_ascii_lowercase();
-                if let Some(special) = SpecialChar::from_char(code) {
-                    text.push(special.to_char());
-                    self.pos += 1;
+        let mut underline = false;
+        let mut overline = false;
+
+        while self.pos < n {
+            let ch = self.chars[self.pos];
+
+            if ch == '%' && self.pos + 1 < n && self.chars[self.pos + 1] == '%' {
+                // `%%%%` → literal `%`.
+                if self.pos + 3 < n
+                    && self.chars[self.pos + 2] == '%'
+                    && self.chars[self.pos + 3] == '%'
+                {
+                    self.pos += 4;
+                    text.push('%');
                     continue;
                 }
-                // Unknown %%? — pass through literally
+                if self.pos + 2 < n {
+                    let code = self.chars[self.pos + 2];
+                    match code.to_ascii_lowercase() {
+                        'u' => {
+                            self.pos += 3;
+                            flush(&mut para, &mut text, underline, overline);
+                            underline = !underline;
+                            continue;
+                        }
+                        'o' => {
+                            self.pos += 3;
+                            flush(&mut para, &mut text, underline, overline);
+                            overline = !overline;
+                            continue;
+                        }
+                        lc @ ('d' | 'p' | 'c') => {
+                            if let Some(sp) = SpecialChar::from_char(lc) {
+                                self.pos += 3;
+                                text.push(sp.to_char());
+                                continue;
+                            }
+                        }
+                        _ if code.is_ascii_digit() => {
+                            // `%%nnn` — up to three decimal digits → character.
+                            self.pos += 2;
+                            let mut digits = String::new();
+                            while digits.len() < 3
+                                && self.pos < n
+                                && self.chars[self.pos].is_ascii_digit()
+                            {
+                                digits.push(self.chars[self.pos]);
+                                self.pos += 1;
+                            }
+                            if let Some(c) = digits.parse::<u32>().ok().and_then(char::from_u32) {
+                                text.push(c);
+                            }
+                            continue;
+                        }
+                        _ => {}
+                    }
+                }
+                // Unknown `%%` code — pass the pair through literally.
+                self.pos += 2;
                 text.push('%');
                 text.push('%');
                 continue;
             }
 
-            // Handle \P paragraph breaks
-            if self.chars[self.pos] == '\\'
-                && self.pos + 1 < self.chars.len()
+            if ch == '\\'
+                && self.pos + 1 < n
                 && (self.chars[self.pos + 1] == 'P' || self.chars[self.pos + 1] == 'p')
             {
-                if !text.is_empty() {
-                    self.current_paragraph = MTextParagraph::from_text(&text);
-                    text.clear();
-                }
-                self.document
-                    .push_paragraph(std::mem::take(&mut self.current_paragraph));
+                flush(&mut para, &mut text, underline, overline);
+                self.document.push_paragraph(std::mem::take(&mut para));
                 self.pos += 2;
                 continue;
             }
 
-            text.push(self.chars[self.pos]);
+            text.push(ch);
             self.pos += 1;
         }
-        if !text.is_empty() {
-            self.current_paragraph = MTextParagraph::from_text(&text);
-        }
-        self.document
-            .push_paragraph(std::mem::take(&mut self.current_paragraph));
+
+        flush(&mut para, &mut text, underline, overline);
+        self.document.push_paragraph(para);
     }
 
     /// Push a copy of the current context onto the stack.
@@ -1230,6 +1285,40 @@ mod tests {
         assert_eq!(
             doc.paragraphs[0].spans[0].properties.height,
             Some(MTextScalar::Factor(2.0))
+        );
+    }
+
+    #[test]
+    fn test_plain_text_underline_toggle() {
+        // TEXT `%%u` toggles underline; each toggle starts a new span.
+        let doc = parse_plain_text("A%%uB%%uC");
+        let spans = &doc.paragraphs[0].spans;
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[0].text, "A");
+        assert!(!spans[0].properties.underline());
+        assert_eq!(spans[1].text, "B");
+        assert!(spans[1].properties.underline());
+        assert_eq!(spans[2].text, "C");
+        assert!(!spans[2].properties.underline());
+    }
+
+    #[test]
+    fn test_plain_text_overline_and_special() {
+        let doc = parse_plain_text("%%oX%%o");
+        assert!(doc.paragraphs[0]
+            .spans
+            .iter()
+            .any(|s| s.text == "X" && s.properties.overline()));
+        // `%%d` still resolves to the degree symbol in plain text.
+        assert_eq!(parse_plain_text("90%%d").paragraphs[0].to_plain_text(), "90°");
+    }
+
+    #[test]
+    fn test_plain_text_decimal_char_code() {
+        // `%%176` → decimal 176 → '°'.
+        assert_eq!(
+            parse_plain_text("%%176").paragraphs[0].to_plain_text(),
+            "°"
         );
     }
 

--- a/src/entities/mtext_format/types.rs
+++ b/src/entities/mtext_format/types.rs
@@ -456,6 +456,36 @@ impl MTextFont {
 // Span Properties
 // ============================================================================
 
+/// A height set by `\H`: either a multiplier on the current height
+/// (`\H<v>x;`, relative) or an absolute drawing-unit height (`\H<v>;`).
+///
+/// The two are kept distinct because a consumer resolves them differently: an
+/// absolute height is divided by the entity's text height to obtain a factor,
+/// while a relative factor applies directly. A prior absolute height carries
+/// through a following relative factor (`\H5;\H2x;` → `Absolute(10)`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum MTextScalar {
+    /// Multiplier relative to the current height (`\H<v>x;`).
+    Factor(f64),
+    /// Absolute drawing-unit height (`\H<v>;`).
+    Absolute(f64),
+}
+
+impl MTextScalar {
+    /// The numeric value, regardless of kind.
+    pub fn value(self) -> f64 {
+        match self {
+            MTextScalar::Factor(v) | MTextScalar::Absolute(v) => v,
+        }
+    }
+
+    /// `true` for a relative (`\H…x;`) factor.
+    pub fn is_relative(self) -> bool {
+        matches!(self, MTextScalar::Factor(_))
+    }
+}
+
 /// Properties applied to a text span.
 #[derive(Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -472,9 +502,9 @@ pub struct SpanProperties {
     /// Font specification. Empty name means inherit.
     pub font: Option<MTextFont>,
 
-    /// Height factor relative to base text height. `None` means 1.0 (default).
-    /// E.g. 0.5 means 50% of base height.
-    pub height: Option<f64>,
+    /// Height from `\H`: a relative factor (`\H<v>x;`) or an absolute
+    /// drawing-unit height (`\H<v>;`). `None` means inherit (default 1.0).
+    pub height: Option<MTextScalar>,
 
     /// Stroke decorations (underline, overline, strikethrough).
     pub stroke: MTextStroke,
@@ -1031,8 +1061,14 @@ impl MTextDocument {
 
         // Height — only emit when changed
         if props.height != current_props.height {
-            if let Some(h) = props.height {
-                write!(result, "\\H{};", h).ok();
+            match props.height {
+                Some(MTextScalar::Factor(v)) => {
+                    write!(result, "\\H{}x;", v).ok();
+                }
+                Some(MTextScalar::Absolute(v)) => {
+                    write!(result, "\\H{};", v).ok();
+                }
+                None => {}
             }
         }
 
@@ -1229,12 +1265,12 @@ mod tests {
         let mut props = SpanProperties::default();
         let mut other = SpanProperties::default();
         other.color = Some(MTextColor::Index(3));
-        other.height = Some(0.5);
+        other.height = Some(MTextScalar::Absolute(0.5));
         other.set_underline(true);
 
         props.merge(&other);
         assert_eq!(props.color, Some(MTextColor::Index(3)));
-        assert_eq!(props.height, Some(0.5));
+        assert_eq!(props.height, Some(MTextScalar::Absolute(0.5)));
         assert!(props.underline());
     }
 

--- a/src/io/dwg/dwg_reader.rs
+++ b/src/io/dwg/dwg_reader.rs
@@ -211,11 +211,20 @@ const ASM_END_MARKER: &[u8] = b"\x0E\x03End\x0E\x02of\x0E\x03ASM\x0D\x04data";
 /// the exact planar/NURBS export), not just ASM bodies read from other apps.
 const ACIS_END_MARKER: &[u8] = b"End-of-ACIS-data";
 
-/// First end-marker (ASM or classic ACIS) at/after `from`, with its length so
+/// First end-marker (ASM or classic ACIS) in `buf[from..to]`, with its length so
 /// the caller can advance past the whole terminator.
-fn find_acds_end(buf: &[u8], from: usize) -> Option<(usize, usize)> {
-    let asm = find_subsequence(buf, ASM_END_MARKER, from).map(|e| (e, ASM_END_MARKER.len()));
-    let acis = find_subsequence(buf, ACIS_END_MARKER, from).map(|e| (e, ACIS_END_MARKER.len()));
+///
+/// `to` bounds the search: a SAB body carries only ONE of the two end-marker
+/// families, so the search for the absent one would otherwise run to the end of
+/// the whole (often hundreds-of-MB) AcDs buffer on every call. With thousands of
+/// records that is O(records × buf) — the dominant cost of opening a 3D-heavy
+/// DWG. Callers pass the tightest known upper bound (segment end, next blob, or
+/// the pre-table region) so a missing marker costs one bounded scan, not a full
+/// one. (#203)
+fn find_acds_end(buf: &[u8], from: usize, to: usize) -> Option<(usize, usize)> {
+    let hay = &buf[..to.min(buf.len())];
+    let asm = find_subsequence(hay, ASM_END_MARKER, from).map(|e| (e, ASM_END_MARKER.len()));
+    let acis = find_subsequence(hay, ACIS_END_MARKER, from).map(|e| (e, ACIS_END_MARKER.len()));
     match (asm, acis) {
         (Some(a), Some(b)) => Some(if a.0 <= b.0 { a } else { b }),
         (a, None) => a,
@@ -300,7 +309,14 @@ fn extract_acds_record_blobs(buf: &[u8]) -> Vec<(u64, Vec<u8>)> {
                 continue;
             };
             let start = region_start + mp;
-            if let Some((end, marker_len)) = find_acds_end(buf, start) {
+            // This record's blob ends at its region boundary; the end marker can
+            // trail a few bytes past `off[r+1]`, so bound to `region_end` plus a
+            // small slack (clamped to the segment). Bounding to `region_end`, not
+            // `seg_end`, is what makes this linear: a big datastore is often ONE
+            // segment (seg_end ≈ buf.len()), so a per-record scan to seg_end for
+            // the absent marker family is still O(records × buf). (#203)
+            let end_bound = (region_end + ASM_END_MARKER.len()).min(seg_end);
+            if let Some((end, marker_len)) = find_acds_end(buf, start, end_bound) {
                 out.push((handle, buf[start..end + marker_len].to_vec()));
             }
         }
@@ -316,7 +332,9 @@ fn extract_acds_record_blobs(buf: &[u8]) -> Vec<(u64, Vec<u8>)> {
             if start >= first_table {
                 break;
             }
-            match find_acds_end(buf, start) {
+            // Pool blobs sit before the first record table, so bound the end
+            // search there rather than scanning into (or past) the tables.
+            match find_acds_end(buf, start, first_table) {
                 Some((end, marker_len)) => {
                     pool.push(buf[start..end + marker_len].to_vec());
                     pos = end + marker_len;
@@ -346,7 +364,12 @@ fn extract_acds_sab_blobs(buf: &[u8]) -> Vec<Vec<u8>> {
     // the buffer is scanned once overall — not once per blob per magic, which
     // was quadratic on 3D-heavy files with many SAB bodies (issue #203).
     while let Some(start) = find_acds_magic(buf, pos) {
-        match find_acds_end(buf, start) {
+        // A body's end marker precedes the next blob's header magic, so bound
+        // the (possibly-absent) marker search there instead of running to the
+        // end of the whole buffer on every blob — the same O(n²) trap as the
+        // record-table path. (#203)
+        let bound = find_acds_magic(buf, start + 1).unwrap_or(buf.len());
+        match find_acds_end(buf, start, bound) {
             Some((end, marker_len)) => {
                 let stop = end + marker_len;
                 blobs.push(buf[start..stop].to_vec());

--- a/src/io/dwg/dwg_stream_readers/bit_reader.rs
+++ b/src/io/dwg/dwg_stream_readers/bit_reader.rs
@@ -799,16 +799,14 @@ impl DwgBitReader {
                 // in the data stream.
                 let is_book_color = (flags & 0x4000) > 0;
 
-                // 0x2000: transparency (BL) — read BEFORE the color-book
-                // handle / rgb, matching the entity ENC field order.
-                if (flags & 0x2000) > 0 {
-                    let value = self.read_bit_long();
-                    transparency = Transparency::from_alpha_value(value as u32);
-                }
-
                 // A true/complex color rgb (BL) is present ONLY when the color
                 // is not a book-color reference (0x4000) but has the 0x8000
                 // flag. A book color carries its rgb via the handle instead.
+                //
+                // Field order in the data stream is rgb/color FIRST, then the
+                // transparency BL. (An entity with both a true colour and a
+                // transparency has flags 0x8000|0x2000 = 0xA000; the rgb long
+                // precedes the transparency long.)
                 let color = if is_book_color {
                     Color::from_index((size & 0x0FFF) as i16)
                 } else if (flags & 0x8000) > 0 {
@@ -831,6 +829,13 @@ impl DwgBitReader {
                     // ACI color index (lower 12 bits)
                     Color::from_index((size & 0x0FFF) as i16)
                 };
+
+                // 0x2000: transparency (BL) — read AFTER the rgb/color-book
+                // value, matching the entity ENC field order.
+                if (flags & 0x2000) > 0 {
+                    let value = self.read_bit_long();
+                    transparency = Transparency::from_alpha_value(value as u32);
+                }
 
                 (color, transparency, is_book_color)
             } else {

--- a/src/io/dwg/dwg_stream_readers/object_reader/entities.rs
+++ b/src/io/dwg/dwg_stream_readers/object_reader/entities.rs
@@ -548,13 +548,18 @@ pub fn read_spline(
     let mut _flags1 = 0i32;
     let mut knot_param = 0i32;
 
-    let scenario;
+    let mut scenario = reader.read_bit_long();
     if version.r2013_plus(dxf_version) {
-        scenario = reader.read_bit_long();
         _flags1 = reader.read_bit_long();
         knot_param = reader.read_bit_long();
-    } else {
-        scenario = reader.read_bit_long();
+        // R2013+ encodes the storage method in `splineflags1`, not the leading
+        // scenario field (which is unreliable here): bit 0 = created from fit
+        // points (scenario 2), bit 1 = control vertices (scenario 1).
+        if _flags1 & 1 != 0 {
+            scenario = 2;
+        } else if _flags1 & 2 != 0 {
+            scenario = 1;
+        }
     }
 
     let degree = reader.read_bit_long();

--- a/src/io/dwg/dwg_stream_writers/bit_writer.rs
+++ b/src/io/dwg/dwg_stream_writers/bit_writer.rs
@@ -719,13 +719,9 @@ impl DwgBitWriter {
 
         self.write_bit_short(flags as i16);
 
-        // Field order matches the entity ENC encoding: transparency BL first,
-        // then the true-color rgb (book colors emit neither — the rgb comes
-        // from the AcDbColor handle).
-        if has_transparency {
-            self.write_bit_long(transparency.to_alpha_value());
-        }
-
+        // Field order matches the entity ENC encoding: the true-color rgb BL
+        // FIRST, then the transparency BL (book colors emit no rgb — it comes
+        // from the AcDbColor handle — but still emit the transparency last).
         if is_true_color && !is_book_color {
             let color_long = match color {
                 Color::Rgb { r, g, b } => {
@@ -738,6 +734,10 @@ impl DwgBitWriter {
                 Color::ByBlock => 0xC3u32 << 24,
             };
             self.write_bit_long(color_long as i32);
+        }
+
+        if has_transparency {
+            self.write_bit_long(transparency.to_alpha_value());
         }
     }
 

--- a/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
@@ -1552,53 +1552,70 @@ impl<'a> DwgObjectWriter<'a> {
             .collect();
 
         for br in &block_records {
+            // An xref block record references an external drawing: its contents
+            // live in that file, not here. Some hosts merge the resolved xref
+            // geometry into the block record for display; serializing those as
+            // owned entities would bind/explode the xref into the host file on
+            // the next open. Write the header with an empty owned list and skip
+            // the entity loop entirely, leaving only the BLOCK/ENDBLK markers.
+            // This matches the reader, which writes/reads no owned-object count
+            // for an xref block (see the `is_xref` guards in the header).
+            let is_xref = br.flags.is_xref || br.flags.is_xref_overlay;
+
             // The block header's owned-handle list MUST match the objects the
             // entity loop below actually writes (br.entity_handles + their
             // sub-entities). Compute that set first.
-            let expanded = self.expand_entity_handles(&br.entity_handles);
-            // Prefer the original DWG-binary order/handles when available, but
-            // only when they describe exactly the same set — otherwise the file
-            // had entities added or removed since it was read and the stored
-            // list is stale, leaving the header pointing at handles that are
-            // never written. AutoCAD stops reading a block's contents at the
-            // first such dangling owned handle, silently dropping every entity
-            // after it. Drop stale entries and fall back to the live set.
-            let entity_handles_for_header = match self.document.block_entity_handles.get(&br.handle) {
-                Some(orig) => {
-                    use std::collections::HashSet;
-                    let valid: HashSet<u64> = expanded.iter().map(|h| h.value()).collect();
-                    let filtered: Vec<Handle> =
-                        orig.iter().copied().filter(|h| valid.contains(&h.value())).collect();
-                    if filtered.len() == expanded.len() {
-                        filtered
-                    } else {
-                        expanded
+            let entity_handles_for_header = if is_xref {
+                Vec::new()
+            } else {
+                let expanded = self.expand_entity_handles(&br.entity_handles);
+                // Prefer the original DWG-binary order/handles when available,
+                // but only when they describe exactly the same set — otherwise
+                // the file had entities added or removed since it was read and
+                // the stored list is stale, leaving the header pointing at
+                // handles that are never written. AutoCAD stops reading a
+                // block's contents at the first such dangling owned handle,
+                // silently dropping every entity after it. Drop stale entries
+                // and fall back to the live set.
+                match self.document.block_entity_handles.get(&br.handle) {
+                    Some(orig) => {
+                        use std::collections::HashSet;
+                        let valid: HashSet<u64> = expanded.iter().map(|h| h.value()).collect();
+                        let filtered: Vec<Handle> =
+                            orig.iter().copied().filter(|h| valid.contains(&h.value())).collect();
+                        if filtered.len() == expanded.len() {
+                            filtered
+                        } else {
+                            expanded
+                        }
                     }
+                    None => expanded,
                 }
-                None => expanded,
             };
             self.write_block_header_with_handles(br, &entity_handles_for_header);
             self.write_block_begin(br);
 
-            // Look up entities by handle from the document
-            let handles = &br.entity_handles;
-            let len = handles.len();
-            for (i, eh) in handles.iter().enumerate() {
-                if let Some(&idx) = self.document.entity_index.get(eh) {
-                    let entity = &self.document.entities[idx];
-                    // Set prev/next for entity linking (pre-R2004)
-                    self.prev_handle = if i > 0 {
-                        Some(handles[i - 1])
-                    } else {
-                        None
-                    };
-                    self.next_handle = if i + 1 < len {
-                        Some(handles[i + 1])
-                    } else {
-                        None
-                    };
+            if !is_xref {
+                // Look up entities by handle from the document
+                let handles = &br.entity_handles;
+                let len = handles.len();
+                for (i, eh) in handles.iter().enumerate() {
+                    if let Some(&idx) = self.document.entity_index.get(eh) {
+                        let entity = &self.document.entities[idx];
+                        // Set prev/next for entity linking (pre-R2004)
+                        self.prev_handle = if i > 0 {
+                            Some(handles[i - 1])
+                        } else {
+                            None
+                        };
+                        self.next_handle = if i + 1 < len {
+                            Some(handles[i + 1])
+                        } else {
+                            None
+                        };
 
-                    self.write_entity(entity);
+                        self.write_entity(entity);
+                    }
                 }
             }
 
@@ -1750,8 +1767,11 @@ impl<'a> DwgObjectWriter<'a> {
                 .write_handle(DwgReferenceType::SoftPointer, last.value());
         }
 
-        // R2004+: entity handles (hard owner)
-        if self.version.r2004_plus() {
+        // R2004+: entity handles (hard owner). Xref blocks own no entities in
+        // the format — the owned-object count is skipped above, so the reader
+        // reads zero handles here. Writing any would desync the handle stream
+        // and corrupt the block record on read, matching the R13-R2000 guard.
+        if self.version.r2004_plus() && !record.flags.is_xref && !record.flags.is_xref_overlay {
             for h in entity_handles {
                 self.writer
                     .write_handle(DwgReferenceType::HardOwnership, h.value());

--- a/src/types/transparency.rs
+++ b/src/types/transparency.rs
@@ -37,14 +37,19 @@ impl Transparency {
     /// Works for both DWG and DXF formats:
     /// - `0` → ByLayer
     /// - Type byte `1` → ByBlock (treated as opaque)
-    /// - Type byte `2` (DXF code 440) → explicit transparency value in low byte
-    /// - Type byte `3` (DWG ENC) → explicit transparency value in low byte
+    /// - Type byte `2` (DXF code 440) → explicit value in low byte
+    /// - Type byte `3` (DWG ENC) → explicit value in low byte
+    ///
+    /// The on-disk low byte is an **alpha/opacity** value (`255` = fully
+    /// opaque, `0` = fully transparent), which is the inverse of this type's
+    /// internal representation (`0` = opaque, `255` = fully transparent), so
+    /// the explicit value is inverted here.
     pub fn from_alpha_value(value: u32) -> Self {
         let type_byte = (value >> 24) as u8;
         match type_byte {
             0 => Transparency::BY_LAYER,
             1 => Transparency::OPAQUE, // BYBLOCK = opaque for now
-            2 | 3 => Transparency((value & 0xFF) as u8),
+            2 | 3 => Transparency(255 - (value & 0xFF) as u8),
             _ => Transparency::OPAQUE,
         }
     }
@@ -81,22 +86,28 @@ impl Transparency {
     pub const T_90: Transparency = Transparency(230);  // 90% transparent
     
     /// Convert to DWG alpha value (32-bit format, type byte 3).
+    ///
+    /// The low byte written is the on-disk **alpha/opacity** (`255` = opaque),
+    /// the inverse of the internal transparency-amount representation.
     pub fn to_alpha_value(&self) -> i32 {
         if self.0 == 0 {
             0
         } else {
-            // Type 3 = explicit value (DWG)
-            ((3u32 << 24) | self.0 as u32) as i32
+            // Type 3 = explicit value (DWG); low byte = opacity = 255 - transparency
+            ((3u32 << 24) | (255 - self.0) as u32) as i32
         }
     }
 
     /// Convert to DXF code 440 value (32-bit format, type byte 2).
+    ///
+    /// The low byte written is the on-disk **alpha/opacity** (`255` = opaque),
+    /// the inverse of the internal transparency-amount representation.
     pub fn to_dxf_value(&self) -> i32 {
         if self.0 == 0 {
             0
         } else {
-            // Type 2 = explicit value (DXF)
-            ((2u32 << 24) | self.0 as u32) as i32
+            // Type 2 = explicit value (DXF); low byte = opacity = 255 - transparency
+            ((2u32 << 24) | (255 - self.0) as u32) as i32
         }
     }
 }
@@ -180,6 +191,31 @@ mod tests {
     #[test]
     fn test_default_transparency() {
         assert_eq!(Transparency::default(), Transparency::OPAQUE);
+    }
+
+    #[test]
+    fn test_packed_value_is_opacity_inverted() {
+        // On-disk low byte is opacity (255 = opaque), inverse of the internal
+        // transparency-amount representation.
+        // 0x020000FF: fully opaque.
+        assert_eq!(Transparency::from_alpha_value(0x0200_00FF), Transparency::OPAQUE);
+        // 0x02000026 (byte 38 opacity) → 85% transparent (internal byte 217).
+        let t = Transparency::from_alpha_value(0x0200_0026);
+        assert_eq!(t.alpha(), 217);
+        assert!((t.as_percent() - 0.85).abs() < 0.01);
+        // 0x02000000 (opacity 0) → fully transparent.
+        assert_eq!(Transparency::from_alpha_value(0x0200_0000), Transparency::TRANSPARENT);
+    }
+
+    #[test]
+    fn test_packed_value_roundtrip() {
+        // An 85%-transparent value (internal 217) writes opacity byte 38 to
+        // both DWG (type 3) and DXF (type 2), and reads back unchanged.
+        let t = Transparency::new(217);
+        assert_eq!(t.to_dxf_value() as u32, 0x0200_0026);
+        assert_eq!(t.to_alpha_value() as u32, 0x0300_0026);
+        assert_eq!(Transparency::from_alpha_value(t.to_dxf_value() as u32), t);
+        assert_eq!(Transparency::from_alpha_value(t.to_alpha_value() as u32), t);
     }
 }
 

--- a/tests/xref_block_roundtrip.rs
+++ b/tests/xref_block_roundtrip.rs
@@ -1,0 +1,115 @@
+//! Regression test for issue #268 (via OpenCADStudio): an xref block must
+//! round-trip through DWG as an *external reference*, not as baked-in geometry.
+//!
+//! Some hosts (e.g. OCS) merge the resolved contents of an xref into its block
+//! record so they can be displayed. Those entities must never be serialized as
+//! owned entities of the xref block — doing so binds/explodes the xref into the
+//! host file, so on the next open the reference is gone and only loose objects
+//! remain. The writer now skips owned-entity output for `is_xref` block records
+//! (and no longer writes their R2004+ owned-handle list, which also desynced
+//! the handle stream).
+
+use std::io::Cursor;
+
+use acadrust::entities::*;
+use acadrust::tables::BlockRecord;
+use acadrust::types::DxfVersion;
+use acadrust::{CadDocument, DwgReader, DwgWriter};
+
+fn dwg_roundtrip(doc: &CadDocument) -> CadDocument {
+    let bytes = DwgWriter::write_to_vec(doc).expect("DWG write failed");
+    DwgReader::from_stream(Cursor::new(bytes))
+        .read()
+        .expect("DWG read failed")
+}
+
+#[test]
+fn xref_block_does_not_bind_owned_entities() {
+    for version in [
+        DxfVersion::AC1018,
+        DxfVersion::AC1024,
+        DxfVersion::AC1027,
+        DxfVersion::AC1032,
+    ] {
+        let mut doc = CadDocument::with_version(version);
+
+        // A genuine model-space entity that must survive untouched — a canary
+        // for handle-stream desync corruption around the xref block.
+        doc.add_entity(EntityType::Circle(Circle::from_coords(5.0, 5.0, 0.0, 3.0)))
+            .unwrap();
+
+        // An xref block record with the flag + path, exactly as XATTACH creates
+        // it before resolution.
+        let mut br = BlockRecord::new("XREF_UNIT");
+        br.handle = doc.allocate_handle();
+        br.block_entity_handle = doc.allocate_handle();
+        br.block_end_handle = doc.allocate_handle();
+        br.flags.is_xref = true;
+        br.xref_path = "./OCS_xref_file.dwg".to_string();
+        let br_handle = br.handle;
+        doc.block_records.add(br).unwrap();
+
+        // Simulate the host merging the resolved xref geometry into the block
+        // record for display: several entities owned by the xref block.
+        for i in 0..5 {
+            let mut e = EntityType::Line(Line::from_coords(0.0, i as f64, 0.0, 10.0, i as f64, 0.0));
+            e.common_mut().owner_handle = br_handle;
+            doc.add_entity(e).unwrap();
+        }
+
+        // Precondition: the merge actually populated the block's owned list.
+        let owned_before = doc
+            .block_records
+            .iter()
+            .find(|b| b.name == "XREF_UNIT")
+            .expect("xref block missing before save")
+            .entity_handles
+            .len();
+        assert_eq!(
+            owned_before, 5,
+            "{version:?}: precondition — merged entities should be present before save"
+        );
+
+        let rt = dwg_roundtrip(&doc);
+
+        // The xref block must survive as a reference.
+        let xref = rt
+            .block_records
+            .iter()
+            .find(|b| b.name == "XREF_UNIT")
+            .unwrap_or_else(|| panic!("{version:?}: xref block record lost on roundtrip"));
+        assert!(
+            xref.flags.is_xref,
+            "{version:?}: is_xref flag lost — the xref was bound/exploded"
+        );
+        assert_eq!(
+            xref.xref_path, "./OCS_xref_file.dwg",
+            "{version:?}: xref path not preserved"
+        );
+        assert!(
+            xref.entity_handles.is_empty(),
+            "{version:?}: xref block still owns {} entities — resolved geometry was baked into the file",
+            xref.entity_handles.len()
+        );
+
+        // None of the merged lines may have been serialized anywhere.
+        let leaked = rt
+            .entities()
+            .filter(|e| matches!(e, EntityType::Line(_)))
+            .count();
+        assert_eq!(
+            leaked, 0,
+            "{version:?}: {leaked} resolved xref line(s) leaked into the saved file"
+        );
+
+        // The genuine model-space circle must survive intact (no desync).
+        let circles = rt
+            .entities()
+            .filter(|e| matches!(e, EntityType::Circle(_)))
+            .count();
+        assert_eq!(
+            circles, 1,
+            "{version:?}: model-space circle lost — the handle stream desynced"
+        );
+    }
+}


### PR DESCRIPTION
Batch of DWG reader/writer correctness fixes, ACIS parse performance, and MTEXT escape-code handling. Verified against real DWG files and ODA/dwgread output where noted.

## DWG fixes
- **ENC transparency field order + opacity inversion** (`4f0599a`): entity color (ENC) read/wrote the transparency `BL` before the RGB, but the real on-disk order is RGB then transparency. Also added the opacity↔transparency inversion (disk byte is opacity, 255 = opaque; internal value is transparency amount). Blocks that should show 85% transparency were reading as 0%. Verified round-trip against ODA both directions.
- **R2013+ spline scenario** (`e8e422a`): the raw "scenario" field is unreliable for R2013+; the real signal is `splineflags1` bit0 (fit) / bit1 (CV). Reader was treating fit data as control points, producing 0 control points / garbage. Now derives the scenario from `splineflags1`.
- **Xref blocks written as references** (`f76e41a`): the writer was baking resolved xref-owned entities into the file, so xrefs exploded on save+reopen. Now skips `is_xref`-owned entities and guards the R2004+ handle loop.

## Performance
- **AcDs SAB end-marker search bound** (`ceef045`): the SAB end-marker scan was unbounded, giving O(n²) parse time on large datastores. Now bounded.
- **O(1) SatDocument::record() lookup** (`4d51947`): record lookup was linear; made it O(1).

## MTEXT
- **Relative vs absolute \H** (`eae0ec3`): distinguish relative vs absolute height changes via a new `MTextScalar` (Factor / Absolute).
- **%%u / %%o / %%nnn in parse_plain_text** (`27b4e47`): handle the legacy TEXT overline/underline/decimal-code sequences in plain-text parsing.
- **Escaped semicolon and caret codes** (`2a2d278`): handle escaped `;` and `^` control codes.

8 commits total. Branch is currently a few commits behind `main`; happy to rebase if preferred.