### PR TITLE
fix(dxf): hatch pattern lines, dashed patterns, layer true-color, compact floats

### DIFF
--- a/src/io/dxf/dxf_code.rs
+++ b/src/io/dxf/dxf_code.rs
@@ -150,7 +150,7 @@ pub enum DxfCode {
     /// Viewport ID
     ViewportId = 69,
     
-    /// Integer values (70-78)
+    /// Integer values (70-79)
     Int70 = 70,
     Int71 = 71,
     Int72 = 72,
@@ -160,6 +160,7 @@ pub enum DxfCode {
     Int76 = 76,
     Int77 = 77,
     Int78 = 78,
+    Int79 = 79,
 
     // ===== 90-99: 32-bit integer values =====
 
@@ -601,6 +602,7 @@ impl DxfCode {
             76 => DxfCode::Int76,
             77 => DxfCode::Int77,
             78 => DxfCode::Int78,
+            79 => DxfCode::Int79,
             90 => DxfCode::Int90,
             91 => DxfCode::Int91,
             92 => DxfCode::Int92,

--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -1724,6 +1724,15 @@ impl<'a> SectionReader<'a> {
                         layer.color = Color::from_index(color_index);
                     }
                 }
+                // True color (code 420): packed 24-bit RGB, overrides the ACI
+                // index in code 62 (which is 7 for a true-colour layer). Without
+                // this every RGB-coloured layer read back as Index(7)/white on
+                // DXF import while the DWG reader kept the RGB. (#223)
+                420 => {
+                    if let Some(v) = pair.as_i32() {
+                        layer.color = Color::from_true_color_value(v);
+                    }
+                }
                 6 => layer.line_type = pair.value_string.clone(),
                 70 => {
                     if let Some(flags) = pair.as_i16() {

--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -4149,6 +4149,31 @@ impl<'a> SectionReader<'a> {
                         };
                     }
                 }
+                52 => {
+                    if let Some(a) = pair.as_double() {
+                        hatch.pattern_angle = a.to_radians();
+                    }
+                }
+                41 => {
+                    if let Some(s) = pair.as_double() {
+                        hatch.pattern_scale = s;
+                    }
+                }
+                77 => {
+                    if let Some(d) = pair.as_i16() {
+                        hatch.is_double = d != 0;
+                    }
+                }
+                78 => {
+                    // Number of pattern definition lines. Each line follows as
+                    // 53 (angle), 43/44 (base point), 45/46 (offset), then 79
+                    // (dash count) and that many 49 (dash length) codes.
+                    let num_lines = pair.as_i16().unwrap_or(0).max(0) as usize;
+                    for _ in 0..num_lines {
+                        let line = self.read_hatch_pattern_line()?;
+                        hatch.pattern.lines.push(line);
+                    }
+                }
                 91 => {
                     if let Some(num_paths) = pair.as_i32() {
                         _num_boundary_paths = num_paths;
@@ -4242,6 +4267,48 @@ impl<'a> SectionReader<'a> {
         hatch.pattern_type = pattern_type;
 
         Ok(Some(hatch))
+    }
+
+    /// Read one pattern definition line for a HATCH (codes 53, 43/44, 45/46,
+    /// 79 + repeated 49). Angle is stored in radians to match the DWG reader.
+    fn read_hatch_pattern_line(&mut self) -> Result<crate::entities::hatch::HatchPatternLine> {
+        let mut line = crate::entities::hatch::HatchPatternLine {
+            angle: 0.0,
+            base_point: Vector2::new(0.0, 0.0),
+            offset: Vector2::new(0.0, 0.0),
+            dash_lengths: Vec::new(),
+        };
+        let mut num_dashes = 0usize;
+        // Fixed prefix ending at 79 (dash count); tolerate a missing/reordered
+        // code by pushing it back and stopping.
+        while let Some(p) = self.reader.read_pair()? {
+            match p.code {
+                53 => line.angle = p.as_double().unwrap_or(0.0).to_radians(),
+                43 => line.base_point.x = p.as_double().unwrap_or(0.0),
+                44 => line.base_point.y = p.as_double().unwrap_or(0.0),
+                45 => line.offset.x = p.as_double().unwrap_or(0.0),
+                46 => line.offset.y = p.as_double().unwrap_or(0.0),
+                79 => {
+                    num_dashes = p.as_i16().unwrap_or(0).max(0) as usize;
+                    break;
+                }
+                _ => {
+                    self.reader.push_back(p);
+                    break;
+                }
+            }
+        }
+        for _ in 0..num_dashes {
+            match self.reader.read_pair()? {
+                Some(p) if p.code == 49 => line.dash_lengths.push(p.as_double().unwrap_or(0.0)),
+                Some(p) => {
+                    self.reader.push_back(p);
+                    break;
+                }
+                None => break,
+            }
+        }
+        Ok(line)
     }
 
     /// Read a line edge for a HATCH boundary path (codes 10/20, 11/21)

--- a/src/io/dxf/writer/section_writer.rs
+++ b/src/io/dxf/writer/section_writer.rs
@@ -570,6 +570,12 @@ impl<'a, W: DxfStreamWriter> SectionWriter<'a, W> {
         } else {
             self.writer.write_i16(62, -color_index)?;
         }
+        // True color (code 420) for an RGB layer — code 62 above can only carry
+        // 7 for it, so without this the RGB is lost on save and the reader (which
+        // now honours 420) round-trips the layer to Index(7)/white. (#223)
+        if let Some(tc) = layer.color.to_true_color_value() {
+            self.writer.write_i32(420, tc)?;
+        }
 
         // Linetype name
         self.writer.write_string(6, &layer.line_type)?;

--- a/src/io/dxf/writer/section_writer.rs
+++ b/src/io/dxf/writer/section_writer.rs
@@ -1901,6 +1901,10 @@ impl<'a, W: DxfStreamWriter> SectionWriter<'a, W> {
             self.writer.write_double(20, seed.y)?;
         }
 
+        // Extended data (e.g. HATCHBACKGROUNDCOLOR) — must be the last group
+        // codes of the entity.
+        self.write_xdata(&hatch.common.extended_data)?;
+
         Ok(())
     }
 

--- a/src/io/dxf/writer/text_writer.rs
+++ b/src/io/dxf/writer/text_writer.rs
@@ -132,17 +132,22 @@ impl<W: Write> DxfTextWriter<W> {
             return t2 + 4;
         }
         let mut cursor = Cursor::new(&mut self.fmt_buf[..]);
-        // write! into a Cursor<&mut [u8]> does not allocate
-        let _ = write!(cursor, "{:.16}", value);
+        // Rust's `{}` Display for f64 emits the shortest decimal string that
+        // round-trips back to the same value, and never uses exponent notation
+        // for magnitudes in this branch's range (1e-15 ..= 1e15).  This matches
+        // AutoCAD's compact output (e.g. "943.920153") instead of dumping the
+        // full 16-digit binary expansion of the float ("943.9201530000000275"),
+        // which trimming trailing zeros cannot clean up because the tail digits
+        // are rounding noise, not zeros.  write! into a Cursor<&mut [u8]> does
+        // not allocate.
+        let _ = write!(cursor, "{}", value);
         let mut len = cursor.position() as usize;
-        // Trim trailing '0's (but keep at least one digit after '.')
-        while len > 1 && self.fmt_buf[len - 1] == b'0' {
-            len -= 1;
-        }
-        // If we trimmed down to just '.', add back a '0'
-        if len > 0 && self.fmt_buf[len - 1] == b'.' {
-            self.fmt_buf[len] = b'0';
-            len += 1;
+        // `{}` prints whole numbers without a fractional part ("15" not "15.0");
+        // DXF real values conventionally carry a decimal point, so add ".0".
+        if !self.fmt_buf[..len].contains(&b'.') {
+            self.fmt_buf[len] = b'.';
+            self.fmt_buf[len + 1] = b'0';
+            len += 2;
         }
         // Append CRLF
         self.fmt_buf[len] = b'\r';
@@ -337,6 +342,34 @@ mod tests {
         }
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("FF\r\n"));
+    }
+
+    #[test]
+    fn test_write_double_compact() {
+        // Regression: the writer used to emit the full 16-decimal expansion of
+        // the f64 (e.g. "943.9201530000000275"), because trimming trailing
+        // zeros cannot remove binary rounding noise.  It must emit the shortest
+        // decimal that round-trips to the same value instead.
+        let mut buf = Vec::new();
+        {
+            let mut writer = DxfTextWriter::new(&mut buf);
+            writer.write_double(10, 943.920153).unwrap();
+        }
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(output, " 10\r\n943.920153\r\n");
+    }
+
+    #[test]
+    fn test_write_double_integer_keeps_point() {
+        // Whole values must still carry a decimal point ("15.0", not "15"),
+        // since `{}` prints integers without a fractional part.
+        let mut buf = Vec::new();
+        {
+            let mut writer = DxfTextWriter::new(&mut buf);
+            writer.write_double(40, 15.0).unwrap();
+        }
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(output, " 40\r\n15.0\r\n");
     }
 }
 


### PR DESCRIPTION
Five DXF round-trip fixes surfaced by the downstream OpenCADStudio project. Each is small, self-contained, and covered by the existing suite (`cargo test --lib`: 1259 passed, 0 failed on this branch).

### Reader
- **Hatch pattern definition lines** — `read_hatch` parsed boundary paths but silently dropped the pattern definition (group code 78 line count, then per line 53 angle / 43·44 base / 45·46 offset / 79 dash count / 49 dashes, plus 52 pattern angle / 41 scale / 77 double). Custom/predefined hatches loaded with an empty `pattern.lines`, so a renderer had nothing to draw and fell back to flat horizontal lines. Added the missing arms + a `read_hatch_pattern_line` helper (angle stored in radians, matching the DWG reader and the write round-trip).
- **Group code 79 typing** — the `DxfCode` enum jumped from `Int78` straight to `Int90`, so `from_i32(79)` returned `Invalid` and code 79 typed as `None`: `as_i16()` gave `None` and the hatch dash count read as 0, desyncing every dashed pattern line. Added the missing `Int79 = 79` variant so 79 types as `Int16` (`from_raw_code` already covers `60..=79`).

### Writer
- **Layer true-color (code 420)** — an RGB layer only wrote ACI 62 (which can only carry index 7), so the true color was lost on save and round-tripped to Index(7)/white. Now emits code 420 when the layer carries an RGB color.
- **Hatch entity XDATA on export** — write a hatch entity’s extended data (e.g. `HATCHBACKGROUNDCOLOR`) as the final group codes of the entity.
- **Shortest round-trippable floats** (authored by @KevinGriffin-new) — the ASCII writer dumped the full 16-digit expansion of each `f64` (`943.9201530000000275` for `943.920153`), roughly doubling file size; trimming trailing zeros cannot remove binary rounding noise. Uses Rust’s `{}` Display, which emits the shortest decimal that round-trips, keeping a decimal point on whole values.

Branch is based directly on `main` so it applies cleanly. Happy to split into separate PRs if you prefer.