### PR TITLE
Preserve class-map dxfnames for unknown DWG objects

### DIFF
--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -837,6 +837,7 @@ impl DwgDocumentBuilder {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 self.process_pass2_record(
                     handle,
+                    raw_type_code,
                     type_code,
                     reader,
                     document,
@@ -1432,6 +1433,7 @@ impl DwgDocumentBuilder {
     fn process_pass2_record(
         &self,
         handle: u64,
+        raw_type_code: i16,
         type_code: i16,
         mut reader: crate::io::dwg::dwg_stream_readers::merged_reader::DwgMergedReader,
         document: &mut CadDocument,
@@ -3403,7 +3405,7 @@ impl DwgDocumentBuilder {
                         .block_visibility_params
                         .insert(Handle::from(handle), param);
 
-                    let type_name = format!("DWG_OBJ_{}", type_code);
+                    let type_name = Self::unknown_object_type_name(document, raw_type_code);
                     let raw_handle_bits = reader.get_handle_bits();
                     let raw_data = reader.raw_merged_data();
                     document.objects.insert(
@@ -3425,7 +3427,7 @@ impl DwgDocumentBuilder {
                         .block_representations
                         .insert(Handle::from(handle), block);
 
-                    let type_name = format!("DWG_OBJ_{}", type_code);
+                    let type_name = Self::unknown_object_type_name(document, raw_type_code);
                     let raw_handle_bits = reader.get_handle_bits();
                     let raw_data = reader.raw_merged_data();
                     document.objects.insert(
@@ -3456,7 +3458,7 @@ impl DwgDocumentBuilder {
                             objects: data.objects.into_iter().map(Handle::from).collect(),
                         },
                     );
-                    let type_name = format!("DWG_OBJ_{}", type_code);
+                    let type_name = Self::unknown_object_type_name(document, raw_type_code);
                     let raw_handle_bits = reader.get_handle_bits();
                     let raw_data = reader.raw_merged_data();
                     document.objects.insert(
@@ -3878,7 +3880,7 @@ impl DwgDocumentBuilder {
                                     .insert(Handle::from(handle), Handle::from(scale));
                             }
                         }
-                        let type_name = format!("DWG_OBJ_{}", type_code);
+                        let type_name = Self::unknown_object_type_name(document, raw_type_code);
                         document.objects.insert(
                             Handle::from(handle),
                             crate::objects::ObjectType::Unknown {
@@ -3925,6 +3927,17 @@ impl DwgDocumentBuilder {
         } else {
             raw
         }
+    }
+
+    /// Name an unsupported object by its CLASSES-section dxfname when the
+    /// drawing's class map knows it, falling back to the positional code.
+    fn unknown_object_type_name(document: &CadDocument, raw_type_code: i16) -> String {
+        document
+            .classes
+            .iter()
+            .find(|class| class.class_number == raw_type_code)
+            .map(|class| class.dxf_name.clone())
+            .unwrap_or_else(|| format!("DWG_OBJ_{}", raw_type_code))
     }
 }
 


### PR DESCRIPTION
## What

Objects that land in `ObjectType::Unknown` are currently named by their positional pass-2 type code, e.g. `DWG_OBJ_524`. The drawing's CLASSES section already knows what these objects are, so this PR resolves the raw class number against the class map and uses its `dxf_name` as the `type_name`, falling back to the old `DWG_OBJ_{code}` pattern when the class map has no entry.

Changes are confined to `process_pass2_record`: the raw (pre-`resolve_type_code`) class number is threaded through as a parameter, the four `Unknown` insertion sites call a new `unknown_object_type_name` helper, and nothing else changes — raw data, handles and round-trip behaviour are untouched.

## Why

On real-world Autodesk Map 3D drawings the unknown-object histogram is dominated by proxy classes. Two concrete examples we hit while building a downstream tool ([dwg2geo](https://github.com/milkway/dwg2geo)):

- City of San Francisco Digital Basemap sheets (AC1032): 10,309 objects reported as `DWG_OBJ_524` become `IRD_OBJ_RECORD`, which makes it immediately visible that the drawing's georeferencing lives in Map 3D industry-record proxies rather than in an `AcDbGeoData` object.
- AutoCAD 2010 "Geospatial Sample.dwg": 10k+ proxy objects gain their real class names (`DMMAP`, `DMMAPMANAGER`, ...), which is what let us prove the file contains no GEODATA instance at all (`instance_count=0` in its class map).

For diagnostics, telemetry and bug reports, `IRD_OBJ_RECORD` is actionable; `DWG_OBJ_524` is not.

## Behaviour note

`type_name` values change for any unknown object whose class is present in the class map, and the fallback now embeds the raw class number instead of the remapped internal code. Anyone matching on the `DWG_OBJ_N` pattern would see the new names; that is the point of the change, but flagging it in case you consider it semver-relevant for the next release.

## Testing

- `cargo build` clean.
- `cargo test`: 1361 passed, 5 failed — the same five round-trip tests (`dwg_roundtrip_deep_r2000/r2013/r2018`, `dwg_roundtrip_complex_linetype_shape`, `dwg_mtext_background_no_regression_all_versions`) fail identically on unpatched `main`, so they are pre-existing and unrelated.
- Exercised against the two Map 3D drawings above through the downstream inspector; unknown-object histograms come out with real class names, and files whose classes are absent from the class map keep the `DWG_OBJ_{code}` fallback.