### PR TITLE
fix(dxf): ensure block name is set to prevent NULL block handle in DW…

### DIFF
--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -1786,7 +1786,11 @@ impl DwgDocumentBuilder {
                     );
                     dim.base.common = entity_common;
                     map_dimension_common(&mut dim.base, &data.common, &maps);
+                    // The DXF writer emits group 10 from the BASE definition
+                    // point — mirror the variant field there or it round-trips
+                    // as (0,0) and regenerating CADs misplace the dimension.
                     dim.definition_point = data.definition_point;
+                    dim.base.definition_point = data.definition_point;
                     dim.rotation = data.rotation;
                     dim.ext_line_rotation = data.ext_line_rotation;
                     let _ = document.add_entity(EntityType::Dimension(
@@ -1804,6 +1808,7 @@ impl DwgDocumentBuilder {
                     dim.base.common = entity_common;
                     map_dimension_common(&mut dim.base, &data.common, &maps);
                     dim.definition_point = data.definition_point;
+                    dim.base.definition_point = data.definition_point;
                     dim.ext_line_rotation = data.ext_line_rotation;
                     let _ = document.add_entity(EntityType::Dimension(
                         Dimension::Aligned(dim),
@@ -1819,6 +1824,7 @@ impl DwgDocumentBuilder {
                     );
                     dim.base.common = entity_common;
                     map_dimension_common(&mut dim.base, &data.common, &maps);
+                    dim.base.definition_point = data.definition_point;
                     dim.leader_length = data.leader_length;
                     let _ = document.add_entity(EntityType::Dimension(
                         Dimension::Radius(dim),
@@ -1834,6 +1840,7 @@ impl DwgDocumentBuilder {
                     );
                     dim.base.common = entity_common;
                     map_dimension_common(&mut dim.base, &data.common, &maps);
+                    dim.base.definition_point = data.definition_point;
                     dim.leader_length = data.leader_length;
                     let _ = document.add_entity(EntityType::Dimension(
                         Dimension::Diameter(dim),
@@ -1851,6 +1858,7 @@ impl DwgDocumentBuilder {
                     dim.second_point = data.second_point;
                     dim.angle_vertex = data.angle_vertex;
                     dim.definition_point = data.definition_point;
+                    dim.base.definition_point = data.definition_point;
                     let _ = document.add_entity(EntityType::Dimension(
                         Dimension::Angular2Ln(dim),
                     ));
@@ -1866,6 +1874,7 @@ impl DwgDocumentBuilder {
                     dim.second_point = data.second_point;
                     dim.angle_vertex = data.angle_vertex;
                     dim.definition_point = data.definition_point;
+                    dim.base.definition_point = data.definition_point;
                     let _ = document.add_entity(EntityType::Dimension(
                         Dimension::Angular3Pt(dim),
                     ));
@@ -1882,6 +1891,7 @@ impl DwgDocumentBuilder {
                     dim.base.common = entity_common;
                     map_dimension_common(&mut dim.base, &data.common, &maps);
                     dim.definition_point = data.definition_point;
+                    dim.base.definition_point = data.definition_point;
                     let _ = document.add_entity(EntityType::Dimension(
                         Dimension::Ordinate(dim),
                     ));

--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -3838,6 +3838,7 @@ impl<'a> SectionReader<'a> {
         let mut fourth_point = PointReader::new();
         let mut text = String::new();
         let mut style_name = String::from("Standard");
+        let mut block_name = String::new();
         let mut layer = String::from("0");
         let mut color = Color::ByLayer;
         let mut line_weight = LineWeight::ByLayer;
@@ -3890,6 +3891,10 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 1 => text = pair.value_string.clone(),
+                // Geometry block reference — without it the DWG writer emits
+                // a NULL block handle and receiving CADs regenerate the
+                // dimension instead of displaying the authored block.
+                2 => block_name = pair.value_string.clone(),
                 3 => style_name = pair.value_string.clone(),
                 10 | 20 | 30 => { definition_point.add_coordinate(&pair); }
                 11 | 21 | 31 => { text_middle_point.add_coordinate(&pair); }
@@ -4065,6 +4070,9 @@ impl<'a> SectionReader<'a> {
             dc.common.linetype = common.linetype;
             dc.common.linetype_scale = common.linetype_scale;
             dc.common.transparency = common.transparency;
+            if !block_name.is_empty() {
+                dc.block_name = block_name;
+            }
             if let Some(pt) = text_middle_point.get_point() {
                 dc.text_middle_point = pt;
             }


### PR DESCRIPTION
This pull request addresses issues with the round-tripping and correct rendering of dimension entities in DWG/DXF files. The main changes ensure that the `definition_point` and `block_name` fields are correctly set on both the base and variant dimension structs, which improves compatibility and fidelity when files are regenerated or opened in other CAD applications.

### Improvements to DWG/DXF round-tripping and CAD compatibility

* Ensured that the `definition_point` is assigned to both the variant and the base dimension structs (e.g., `dim.base.definition_point = data.definition_point`) for all dimension types in `dwg_document_builder.rs`. This prevents the field from defaulting to (0,0), which previously caused misplacement of dimensions in some CAD tools. [[1]](diffhunk://#diff-1caf42379881555263d040160e7d78cb763439c7e3233e2393a4818dc4fe7b59R1789-R1793) [[2]](diffhunk://#diff-1caf42379881555263d040160e7d78cb763439c7e3233e2393a4818dc4fe7b59R1811) [[3]](diffhunk://#diff-1caf42379881555263d040160e7d78cb763439c7e3233e2393a4818dc4fe7b59R1827) [[4]](diffhunk://#diff-1caf42379881555263d040160e7d78cb763439c7e3233e2393a4818dc4fe7b59R1843) [[5]](diffhunk://#diff-1caf42379881555263d040160e7d78cb763439c7e3233e2393a4818dc4fe7b59R1861) [[6]](diffhunk://#diff-1caf42379881555263d040160e7d78cb763439c7e3233e2393a4818dc4fe7b59R1877) [[7]](diffhunk://#diff-1caf42379881555263d040160e7d78cb763439c7e3233e2393a4818dc4fe7b59R1894)
* In the DXF reader, added support for reading and storing the geometry block reference (`block_name`) from group code 2, ensuring that dimensions reference the correct block and are not regenerated incorrectly by receiving CADs. [[1]](diffhunk://#diff-28d290aa02113b1902f2475c6698cb84d0fbf4bed8f2aeb77c69a9b3e56025c4R3841) [[2]](diffhunk://#diff-28d290aa02113b1902f2475c6698cb84d0fbf4bed8f2aeb77c69a9b3e56025c4R3894-R3897)
* Updated the logic so that if a `block_name` is present, it is assigned to the dimension's common data (`dc.block_name`), improving fidelity when importing/exporting dimensions.