### PR TITLE
Fix remapping of entity extension dictionaries

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -3977,7 +3977,11 @@ impl CadDocument {
             // definition object stays linked (RasterImage/Underlay renderers
             // look the definition up by this handle to find the file path).
             for entity in self.entities.iter_mut() {
-                match Arc::make_mut(entity) {
+                let entity = Arc::make_mut(entity);
+                if let Some(handle) = entity.common_mut().xdictionary_handle.as_mut() {
+                    remap_object_handle(handle);
+                }
+                match entity {
                     EntityType::Insert(insert) => {
                         if let Some(handle) = &mut insert.view_rep_handle {
                             remap_object_handle(handle);

--- a/tests/resolve_references_xdictionary.rs
+++ b/tests/resolve_references_xdictionary.rs
@@ -1,0 +1,40 @@
+use acadrust::entities::Line;
+use acadrust::objects::{Dictionary, ObjectType};
+use acadrust::types::{Handle, Vector3};
+use acadrust::{CadDocument, EntityType};
+
+#[test]
+fn remaps_entity_xdictionary_reference_with_colliding_object() {
+    let mut document = CadDocument::new();
+    let colliding = Handle::new(0x100);
+
+    let mut line = Line::from_points(Vector3::ZERO, Vector3::UNIT_X);
+    line.common.handle = colliding;
+    line.common.xdictionary_handle = Some(colliding);
+    document.add_entity(EntityType::Line(line)).unwrap();
+
+    let mut extension_dictionary = Dictionary::new();
+    extension_dictionary.handle = colliding;
+    extension_dictionary.owner = colliding;
+    document
+        .objects
+        .insert(colliding, ObjectType::Dictionary(extension_dictionary));
+
+    document.resolve_references();
+
+    let line = document
+        .entities()
+        .find_map(|entity| match entity {
+            EntityType::Line(line) if line.common.handle == colliding => Some(line),
+            _ => None,
+        })
+        .unwrap();
+    let remapped_dictionary = line.common.xdictionary_handle.unwrap();
+
+    assert_ne!(remapped_dictionary, colliding);
+    assert!(matches!(
+        document.objects.get(&remapped_dictionary),
+        Some(ObjectType::Dictionary(dictionary))
+            if dictionary.handle == remapped_dictionary
+    ));
+}


### PR DESCRIPTION
## Problem

CadDocument::resolve_references moves an object when its handle collides with a non-object record, but it does not update EntityCommon::xdictionary_handle. The entity can therefore keep pointing to the old handle after its extension dictionary has moved. For INSERT entities, that can orphan ACAD_FILTER/SPATIAL_FILTER data used by XCLIP during a later DWG write.

## Fix

Remap the common extension-dictionary handle in the existing entity-to-object reference pass.

## Regression test

The test creates a line and extension dictionary with the same handle, forcing resolve_references to move the dictionary. It then verifies that the entity follows the new handle and that the dictionary's map key and internal handle agree.

The test fails on current main before the fix and passes afterward.