### PR TITLE
Write BlockRecord base points to DWG

### DIFF
--- a/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
@@ -2035,7 +2035,7 @@ impl<'a> DwgObjectWriter<'a> {
                     None
                 }
             })
-            .unwrap_or(crate::types::Vector3::ZERO);
+            .unwrap_or(record.base_point);
         self.writer.write_3bit_double(base_pt);
 
         // Xref path

--- a/tests/block_base_point.rs
+++ b/tests/block_base_point.rs
@@ -1,0 +1,32 @@
+use acadrust::tables::TableEntry;
+use acadrust::types::{DxfVersion, Vector3};
+use acadrust::{CadDocument, DwgReader, DwgWriter};
+use std::io::Cursor;
+
+#[test]
+fn writes_block_record_base_point_without_a_block_marker() {
+    for version in [
+        DxfVersion::AC1015,
+        DxfVersion::AC1018,
+        DxfVersion::AC1021,
+        DxfVersion::AC1024,
+        DxfVersion::AC1027,
+        DxfVersion::AC1032,
+    ] {
+        let mut document = CadDocument::with_version(version);
+        let mut record = acadrust::tables::BlockRecord::new("Desk");
+        record.set_handle(document.allocate_handle());
+        record.block_end_handle = document.allocate_handle();
+        record.base_point = Vector3::new(50.0, 25.0, 0.0);
+        document.block_records.add(record).unwrap();
+
+        let bytes = DwgWriter::write_to_vec(&document).unwrap();
+        let mut reader = DwgReader::from_stream(Cursor::new(bytes));
+        let roundtripped = reader.read().unwrap();
+        assert_eq!(
+            roundtripped.block_records.get("Desk").unwrap().base_point,
+            Vector3::new(50.0, 25.0, 0.0),
+            "failed for {version:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

The DWG writer obtains a block header's base point only by searching BlockRecord::entity_handles for a BLOCK marker. CadDocument::add_entity deliberately does not add structural BLOCK markers to that member list, so a directly populated BlockRecord::base_point is written as zero.

## Fix

Keep the existing BLOCK-marker value as first priority, but fall back to BlockRecord::base_point when no marker is listed.

## Regression test

Create a block record with a non-zero base and no marker, write/read it, and verify the base survives. The test covers R2000, R2004, R2007, R2010, R2013, and R2018.