### PR TITLE
Match model and paper space records case-insensitively

### DIFF
--- a/src/tables/block_record.rs
+++ b/src/tables/block_record.rs
@@ -145,12 +145,14 @@ impl BlockRecord {
 
     /// Check if this is a model space block
     pub fn is_model_space(&self) -> bool {
-        self.name == "*Model_Space"
+        self.name.eq_ignore_ascii_case("*Model_Space")
     }
 
     /// Check if this is a paper space block
     pub fn is_paper_space(&self) -> bool {
-        self.name.starts_with("*Paper_Space")
+        self.name
+            .get(.."*Paper_Space".len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("*Paper_Space"))
     }
 
     /// Check if this is a layout block
@@ -195,6 +197,15 @@ mod tests {
         let block = BlockRecord::new("MyBlock");
         assert_eq!(block.name, "MyBlock");
         assert!(block.explodable);
+    }
+
+    #[test]
+    fn space_record_names_are_ascii_case_insensitive() {
+        assert!(BlockRecord::new("*MODEL_SPACE").is_model_space());
+        assert!(BlockRecord::new("*model_space").is_model_space());
+        assert!(BlockRecord::new("*PAPER_SPACE").is_paper_space());
+        assert!(BlockRecord::new("*paper_space12").is_paper_space());
+        assert!(!BlockRecord::new("*paperwork").is_paper_space());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

DWG reserved block-record names are not guaranteed to retain canonical casing. The DWG builder already recognizes *Model_Space and *Paper_Space case-insensitively, but BlockRecord::is_model_space and is_paper_space still use case-sensitive checks. Uppercase or lowercase records can therefore be misclassified by later document logic.

## Fix

Use ASCII-case-insensitive matching for both helpers while preserving the existing numbered paper-space prefix behavior.

## Tests

Cover uppercase and lowercase model space, base and numbered paper space, plus a non-space prefix.