### PR TITLE
Write objects in handle order so the same document writes the same bytes

### DIFF
--- a/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
@@ -2203,13 +2203,16 @@ impl<'a> DwgObjectWriter<'a> {
             self.visited_objects.insert(Handle::from(handle_val));
         }
 
-        let remaining: Vec<(Handle, crate::objects::ObjectType)> = self
+        let mut remaining: Vec<(Handle, crate::objects::ObjectType)> = self
             .document
             .objects
             .iter()
             .filter(|(h, _)| !self.visited_objects.contains(h))
             .map(|(h, o)| (*h, o.clone()))
             .collect();
+        // `objects` is a HashMap: iterate in handle order so the same
+        // document writes the same bytes on every call.
+        remaining.sort_by_key(|(h, _)| h.value());
 
         for (handle, obj) in remaining {
             self.visited_objects.insert(handle);

--- a/src/io/dwg/dwg_writer.rs
+++ b/src/io/dwg/dwg_writer.rs
@@ -343,15 +343,17 @@ fn prepare_header(
                 }
             });
         if !mls_valid {
-            h.current_multiline_style_handle = Handle::NULL;
-            for (_, obj) in &document.objects {
-                if let crate::objects::ObjectType::MLineStyle(mls) = obj {
-                    if mls.name == "Standard" {
-                        h.current_multiline_style_handle = mls.handle;
-                        break;
-                    }
-                }
-            }
+            // Lowest handle wins: `objects` is a HashMap, and a first-match
+            // scan would pick a different "Standard" style on each call.
+            h.current_multiline_style_handle = document
+                .objects
+                .values()
+                .filter_map(|obj| match obj {
+                    crate::objects::ObjectType::MLineStyle(mls) if mls.name == "Standard" => Some(mls.handle),
+                    _ => None,
+                })
+                .min_by_key(|handle| handle.value())
+                .unwrap_or(Handle::NULL);
         }
     }
 

--- a/src/io/dxf/writer/section_writer.rs
+++ b/src/io/dxf/writer/section_writer.rs
@@ -5025,8 +5025,12 @@ impl<'a, W: DxfStreamWriter> SectionWriter<'a, W> {
             self.write_dictionary(root_dict, &document.objects)?;
         }
 
-        // Write remaining objects (skip the root dictionary already written)
-        for (handle, object) in document.objects.iter() {
+        // Write remaining objects (skip the root dictionary already written).
+        // `objects` is a HashMap: iterate in handle order so the same
+        // document writes the same bytes on every call.
+        let mut remaining: Vec<(&Handle, &ObjectType)> = document.objects.iter().collect();
+        remaining.sort_by_key(|(handle, _)| handle.value());
+        for (handle, object) in remaining {
             if *handle == root_handle {
                 continue;
             }

--- a/tests/deterministic_output.rs
+++ b/tests/deterministic_output.rs
@@ -1,0 +1,67 @@
+//! Writing the same document twice must produce the same bytes.
+//!
+//! `CadDocument::objects` is a `HashMap`, and every map hashes with its own
+//! random state, so iterating it directly makes the output depend on the
+//! iteration order of the moment. The writers sort by handle wherever they
+//! walk that map: the DWG object writer for the orphaned objects it drains
+//! in its second phase, the DXF section writer for the OBJECTS section, and
+//! the "Standard" MLINESTYLE fallback in the header. These tests pin that
+//! down with enough orphaned objects that an unsorted walk cannot pass by
+//! luck.
+
+use acadrust::objects::{Dictionary, ObjectType};
+use acadrust::{CadDocument, DwgWriter, DxfWriter};
+
+/// Dictionaries that no other object owns: exactly the objects the DWG
+/// writer only reaches in its second phase, and a permutation the DXF
+/// OBJECTS section shows in full.
+const ORPHANED_DICTIONARIES: usize = 32;
+
+fn document_with_orphaned_objects() -> CadDocument {
+    let mut document = CadDocument::new();
+
+    for index in 0..ORPHANED_DICTIONARIES {
+        let handle = document.allocate_handle();
+        let mut dictionary = Dictionary::new();
+        dictionary.handle = handle;
+        dictionary.add_entry(format!("ENTRY_{index}"), handle);
+        document
+            .objects
+            .insert(handle, ObjectType::Dictionary(dictionary));
+    }
+
+    document
+}
+
+fn assert_three_runs_are_byte_identical(label: &str, write: impl Fn() -> Vec<u8>) {
+    let first = write();
+
+    for run in 2..=3 {
+        let again = write();
+        assert_eq!(
+            first.len(),
+            again.len(),
+            "{label}: run {run} has a different length"
+        );
+
+        if let Some(offset) = first.iter().zip(&again).position(|(a, b)| a != b) {
+            panic!("{label}: run {run} differs at byte offset {offset}");
+        }
+    }
+}
+
+#[test]
+fn dxf_output_is_byte_identical_across_runs() {
+    assert_three_runs_are_byte_identical("DXF", || {
+        let document = document_with_orphaned_objects();
+        DxfWriter::new(&document).write_to_vec().expect("DXF write")
+    });
+}
+
+#[test]
+fn dwg_output_is_byte_identical_across_runs() {
+    assert_three_runs_are_byte_identical("DWG", || {
+        let document = document_with_orphaned_objects();
+        DwgWriter::write_to_vec(&document).expect("DWG write")
+    });
+}


### PR DESCRIPTION
`CadDocument::objects` is a `HashMap`, and both writers iterated it directly: the DWG object writer for the orphaned objects it drains in its second phase, the DXF section writer for the whole OBJECTS section, and `prepare_header` when it falls back to a "Standard" MLINESTYLE. Every iteration order is different, so exporting the same document twice produced two different files (a permutation of the OBJECTS section in DXF, shifted object records and object map in DWG).

Sort by handle before iterating in each of the three places, the same way the handle remap already sorts before renumbering. A new test writes a document with 32 orphaned dictionaries three times in each format and fails on the first differing byte; both cases fail before this change and pass after it.

Fix #71 