### PR TITLE
fix(dxf): keep a true colour written in its unsigned AcCmColor spelling

### DIFF
--- a/src/io/dxf/reader/section_reader.rs
+++ b/src/io/dxf/reader/section_reader.rs
@@ -1091,7 +1091,9 @@ fn dynamic_dxf_history_base(fields: &DynamicDxfFields) -> SolidHistoryNodeBase {
     let color = if fields.values(section, 420).is_empty() {
         Color::from_index(fields.i16(section, 62))
     } else {
-        Color::from_true_color_value(fields.i32(section, 420))
+        Color::from_true_color_value(
+            true_color_bits(&fields.text(section, 420)).unwrap_or_default(),
+        )
     };
     SolidHistoryNodeBase {
         eval: dynamic_dxf_eval(fields),
@@ -6934,7 +6936,7 @@ impl<'a> SectionReader<'a> {
                     }
                     420 => {
                         pending_property = Some(VisualStylePropertyValue::Color(
-                            Color::from_true_color_value(pair.as_i32().unwrap_or_default()),
+                            Color::from_true_color_value(pair.as_i32_bits().unwrap_or_default()),
                         ));
                         continue;
                     }
@@ -6984,7 +6986,7 @@ impl<'a> SectionReader<'a> {
                     }
                     420 => {
                         pending_property = Some(VisualStylePropertyValue::Color(
-                            Color::from_true_color_value(pair.as_i32().unwrap_or_default()),
+                            Color::from_true_color_value(pair.as_i32_bits().unwrap_or_default()),
                         ));
                     }
                     _ => {}
@@ -7021,8 +7023,9 @@ impl<'a> SectionReader<'a> {
                             ..
                         }) = legacy_properties.last_mut()
                         {
-                            *value =
-                                Color::from_true_color_value(pair.as_i32().unwrap_or_default());
+                            *value = Color::from_true_color_value(
+                                pair.as_i32_bits().unwrap_or_default(),
+                            );
                         }
                         None
                     }
@@ -7245,7 +7248,7 @@ impl<'a> SectionReader<'a> {
                         if let Some(true_color) = self.reader.read_pair()? {
                             if true_color.code == 420 {
                                 color = Color::from_true_color_value(
-                                    true_color.as_i32().unwrap_or_default(),
+                                    true_color.as_i32_bits().unwrap_or_default(),
                                 );
                             } else {
                                 self.reader.push_back(true_color);
@@ -7254,7 +7257,7 @@ impl<'a> SectionReader<'a> {
                         Some(MaterialProceduralValue::Color(color))
                     }
                     420 => Some(MaterialProceduralValue::Color(
-                        Color::from_true_color_value(kind.as_i32().unwrap_or_default()),
+                        Color::from_true_color_value(kind.as_i32_bits().unwrap_or_default()),
                     )),
                     301 => Some(MaterialProceduralValue::Text(kind.value_string)),
                     300 => {
@@ -7333,13 +7336,13 @@ impl<'a> SectionReader<'a> {
                 70 => obj.ambient_color.flag = pair.as_i16().unwrap_or_default() as u8,
                 40 => obj.ambient_color.factor = pair.as_double().unwrap_or_default(),
                 90 if !ambient_rgb_seen && obj.ambient_color.flag == 1 => {
-                    obj.ambient_color.rgb = pair.as_i32();
+                    obj.ambient_color.rgb = pair.as_i32_bits();
                     ambient_rgb_seen = true;
                 }
                 90 => obj.self_illumination = pair.as_i32().unwrap_or_default() as f64,
                 71 => obj.diffuse_color.flag = pair.as_i16().unwrap_or_default() as u8,
                 41 => obj.diffuse_color.factor = pair.as_double().unwrap_or_default(),
-                91 => obj.diffuse_color.rgb = pair.as_i32(),
+                91 => obj.diffuse_color.rgb = pair.as_i32_bits(),
                 42 if advanced => {
                     obj.normal_map.blend_factor = pair.as_double().unwrap_or_default()
                 }
@@ -7384,7 +7387,7 @@ impl<'a> SectionReader<'a> {
                 }
                 76 => obj.specular_color.flag = pair.as_i16().unwrap_or_default() as u8,
                 45 => obj.specular_color.factor = pair.as_double().unwrap_or_default(),
-                92 => obj.specular_color.rgb = pair.as_i32(),
+                92 => obj.specular_color.rgb = pair.as_i32_bits(),
                 44 => obj.specular_gloss_factor = pair.as_double().unwrap_or_default(),
                 46 => obj.specular_map.blend_factor = pair.as_double().unwrap_or_default(),
                 77 => {
@@ -8089,8 +8092,9 @@ impl<'a> SectionReader<'a> {
                 420 => {
                     if let DataObjectData::CellStyleMap(value) = &mut obj.data {
                         if let Some(cell) = value.cells.last_mut() {
-                            let color =
-                                Color::from_true_color_value(pair.as_i32().unwrap_or_default());
+                            let color = Color::from_true_color_value(
+                                pair.as_i32_bits().unwrap_or_default(),
+                            );
                             match style_section.as_str() {
                                 "TABLEFORMAT_BEGIN" => {
                                     cell.cell_style.background_color = color;
@@ -8427,7 +8431,7 @@ impl<'a> SectionReader<'a> {
                 1 => obj.color_name = pair.value_string.clone(),
                 2 => obj.book_name = pair.value_string.clone(),
                 62 => indexed_color = pair.as_i16().map(Color::from_index),
-                420 => true_color = pair.as_i32().map(Color::from_true_color_value),
+                420 => true_color = pair.as_i32_bits().map(Color::from_true_color_value),
                 430 => {
                     let (book_name, color_name) =
                         crate::io::dxf::split_color_book_name(&pair.value_string);
@@ -8788,7 +8792,7 @@ impl<'a> SectionReader<'a> {
                 // this every RGB-coloured layer read back as Index(7)/white on
                 // DXF import while the DWG reader kept the RGB. (#223)
                 420 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         layer.color = Color::from_true_color_value(v);
                     }
                 }
@@ -9890,7 +9894,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 421 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         view.ambient_color = Color::from_true_color_value(v);
                     }
                 }
@@ -10267,7 +10271,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 421 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         vport.ambient_color = Color::from_true_color_value(v);
                     }
                 }
@@ -10524,7 +10528,7 @@ impl<'a> SectionReader<'a> {
             }
             // True color (code 420): packed 24-bit RGB overrides ACI index.
             420 => {
-                if let Some(v) = pair.as_i32() {
+                if let Some(v) = pair.as_i32_bits() {
                     common.color = Color::from_true_color_value(v);
                 }
                 Ok(true)
@@ -11694,7 +11698,7 @@ impl<'a> SectionReader<'a> {
                                 }
                             }
                             420 => {
-                                if let Some(tc) = vpair.as_i32() {
+                                if let Some(tc) = vpair.as_i32_bits() {
                                     vcolor = Some(Color::from_true_color_value(tc));
                                 }
                             }
@@ -12358,7 +12362,7 @@ impl<'a> SectionReader<'a> {
                 421 => {
                     // Background fill true colour (24-bit RGB); same typing
                     // caveat as 63 — parse the raw value directly.
-                    if let Ok(v) = pair.value_string.trim().parse::<i32>() {
+                    if let Some(v) = true_color_bits(&pair.value_string) {
                         mtext.background_color = Color::from_true_color_value(v);
                     }
                 }
@@ -13268,7 +13272,7 @@ impl<'a> SectionReader<'a> {
                 77 => data.character_set = pair.as_i16().unwrap_or(0),
                 78 => data.pitch_and_family = pair.as_i16().unwrap_or(0),
                 79 => data.is_shx = pair.as_i16().unwrap_or(0) != 0,
-                90 => data.text_color = pair.as_i32().unwrap_or(0),
+                90 => data.text_color = pair.as_i32_bits().unwrap_or(0),
                 210 | 220 | 230 => {
                     normal.add_coordinate(&pair);
                 }
@@ -14657,9 +14661,9 @@ impl<'a> SectionReader<'a> {
                                 }
                             }
                             421 => {
-                                if let (Some(entry), Ok(rgb)) = (
+                                if let (Some(entry), Some(rgb)) = (
                                     hatch.gradient_color.colors.last_mut(),
-                                    gp.value_string.trim().parse::<i32>(),
+                                    true_color_bits(&gp.value_string),
                                 ) {
                                     entry.color = Color::from_true_color_value(rgb);
                                 }
@@ -16542,7 +16546,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 91 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         ml.line_color = color_from_i32(v);
                     }
                 }
@@ -16618,7 +16622,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 92 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         ml.text_color = color_from_i32(v);
                     }
                 }
@@ -16633,7 +16637,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 93 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         ml.block_content_color = color_from_i32(v);
                     }
                 }
@@ -16889,7 +16893,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 90 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         ctx.text_color = color_from_i32(v);
                     }
                 }
@@ -16904,7 +16908,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 91 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         ctx.background_fill_color = color_from_i32(v);
                     }
                 }
@@ -16988,7 +16992,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 93 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         ctx.block_content_color = color_from_i32(v);
                     }
                 }
@@ -17228,7 +17232,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 92 => {
-                    if let Some(v) = pair.as_i32() {
+                    if let Some(v) = pair.as_i32_bits() {
                         line.line_color = color_from_i32(v);
                     }
                 }
@@ -17856,7 +17860,10 @@ impl<'a> SectionReader<'a> {
                 63 if !in_photometric => {
                     light.light_color = Color::from_index(pair.as_i16().unwrap_or(256))
                 }
-                421 => light.light_color = Color::from_true_color_value(pair.as_i32().unwrap_or(0)),
+                421 => {
+                    light.light_color =
+                        Color::from_true_color_value(pair.as_i32_bits().unwrap_or(0))
+                }
                 291 => light.plot_glyph = pair.as_i16().unwrap_or(0) != 0,
                 40 if !in_photometric => {
                     light.intensity = pair.as_double().unwrap_or(light.intensity)
@@ -19979,7 +19986,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 420 | 421 => {
-                    if let (Some(row), Some(v)) = (rows.last_mut(), pair.as_i32()) {
+                    if let (Some(row), Some(v)) = (rows.last_mut(), pair.as_i32_bits()) {
                         let color = Color::from_true_color_value(v);
                         if pair.code == 420 {
                             row.text_color = color;
@@ -19989,7 +19996,7 @@ impl<'a> SectionReader<'a> {
                     }
                 }
                 422..=427 => {
-                    if let (Some(row), Some(v)) = (rows.last_mut(), pair.as_i32()) {
+                    if let (Some(row), Some(v)) = (rows.last_mut(), pair.as_i32_bits()) {
                         border_mut(row, (pair.code - 422) as usize).color =
                             Color::from_true_color_value(v);
                     }
@@ -20137,6 +20144,20 @@ impl<'a> SectionReader<'a> {
     }
 }
 
+/// Parse a colour group code's raw text into a 32-bit bit pattern.
+///
+/// The string counterpart of [`DxfCodePair::as_i32_bits`], for the sites that
+/// read code 420/421 straight off `value_string`. A true colour carrying
+/// AutoCAD's `0xC2` method byte does not fit an `i32` when written unsigned,
+/// so a plain `parse::<i32>()` drops it and the entity keeps its ACI index.
+fn true_color_bits(raw: &str) -> Option<i32> {
+    let value = raw.trim().parse::<i64>().ok()?;
+
+    i32::try_from(value)
+        .ok()
+        .or_else(|| u32::try_from(value).ok().map(|bits| bits as i32))
+}
+
 /// Decode a colour stored as a raw CMC i32 (MULTILEADER 90/91/92/93 codes).
 fn color_from_i32(v: i32) -> Color {
     // AutoCAD-produced DXF encodes a color in the high "method" byte:
@@ -20173,6 +20194,29 @@ fn color_from_i32(v: i32) -> Color {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `true_color_bits` reads the raw text of a colour code, so unlike
+    /// [`DxfCodePair::as_i32_bits`] it owns the parse: it must trim, accept
+    /// both spellings of the same 32-bit word, and refuse anything wider or
+    /// non-numeric rather than fold it into a plausible colour.
+    #[test]
+    fn true_color_bits_accepts_both_spellings_and_refuses_the_rest() {
+        // 0xC2FF8800, the AcCmColor word for a plain orange, either way round.
+        assert_eq!(true_color_bits("3271526400"), Some(-1_023_440_896));
+        assert_eq!(true_color_bits("-1023440896"), Some(-1_023_440_896));
+        // The bare 24 bits, and the two ends of each half of the range.
+        assert_eq!(true_color_bits("16746496"), Some(16_746_496));
+        assert_eq!(true_color_bits("2147483647"), Some(i32::MAX));
+        assert_eq!(true_color_bits("2147483648"), Some(i32::MIN));
+        assert_eq!(true_color_bits("4294967295"), Some(-1));
+        // Surrounding whitespace is the reader's, not the file's.
+        assert_eq!(true_color_bits("  3271526400\r\n"), Some(-1_023_440_896));
+        // Wider than 32 bits on either side, and not a number at all.
+        assert_eq!(true_color_bits("4294967296"), None);
+        assert_eq!(true_color_bits("-2147483649"), None);
+        assert_eq!(true_color_bits(""), None);
+        assert_eq!(true_color_bits("ff8800"), None);
+    }
 
     /// Helper: create a document, write to DXF, read back.
     fn roundtrip(doc: CadDocument) -> CadDocument {

--- a/src/io/dxf/reader/stream_reader.rs
+++ b/src/io/dxf/reader/stream_reader.rs
@@ -124,6 +124,30 @@ impl DxfCodePair {
         }
     }
 
+    /// Get value as a 32-bit *bit pattern*, accepting the unsigned spelling.
+    ///
+    /// A colour code (420, 421, and the `AcCmColor` values MLEADER carries in
+    /// its 90-series codes) is a packed word, not a quantity: AutoCAD sets a
+    /// method byte in the high position, `0xC2` for a true colour, so a plain
+    /// RGB such as `0xC2FF8800` is written by some producers as the unsigned
+    /// `3271526400` and by others as the signed `-1023440896`. Only the second
+    /// fits an `i32`, so [`as_i32`](Self::as_i32) drops the first, the colour
+    /// never reaches the entity, and it falls back to its ACI index, which for
+    /// a true-coloured entity is usually 256 (`ByLayer`).
+    ///
+    /// Reinterpreting the unsigned spelling as its two's complement keeps both,
+    /// and the downstream decoders already mask the method byte off. Codes that
+    /// carry a real number keep using `as_i32`: a flags word of three billion is
+    /// a malformed file, not a negative count.
+    pub fn as_i32_bits(&self) -> Option<i32> {
+        match self.typed_value {
+            CodePairValue::Int(v) => i32::try_from(v)
+                .ok()
+                .or_else(|| u32::try_from(v).ok().map(|bits| bits as i32)),
+            _ => None,
+        }
+    }
+
     /// Get value as double
     pub fn as_double(&self) -> Option<f64> {
         match self.typed_value {
@@ -248,5 +272,61 @@ impl PointReader {
 impl Default for PointReader {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Code 420 is an Int32 group code, so `DxfCodePair::new` parses its text
+    /// into `CodePairValue::Int` and the accessors below see an `i64`.
+    fn true_color_pair(text: &str) -> DxfCodePair {
+        DxfCodePair::new(420, text.to_string())
+    }
+
+    #[test]
+    fn as_i32_bits_keeps_what_as_i32_already_kept() {
+        for text in [
+            "0",
+            "16746496",
+            "-1023440896",
+            "-1",
+            "2147483647",
+            "-2147483648",
+        ] {
+            let pair = true_color_pair(text);
+
+            assert_eq!(pair.as_i32_bits(), pair.as_i32(), "spelled {text}");
+            assert!(pair.as_i32_bits().is_some(), "spelled {text}");
+        }
+    }
+
+    /// The whole point: the unsigned half of the 32-bit range, which `as_i32`
+    /// rejects, comes back as the same bit pattern read signed.
+    #[test]
+    fn as_i32_bits_accepts_the_unsigned_half_of_the_range() {
+        for (unsigned, signed) in [
+            ("2147483648", i32::MIN),
+            ("3271526400", -1_023_440_896), // 0xC2FF8800, a true colour
+            ("4294967295", -1),
+        ] {
+            let pair = true_color_pair(unsigned);
+
+            assert_eq!(pair.as_i32(), None, "as_i32 should still reject {unsigned}");
+            assert_eq!(pair.as_i32_bits(), Some(signed), "spelled {unsigned}");
+        }
+    }
+
+    /// Past `u32::MAX` there is no bit pattern to reinterpret, and a code that
+    /// carries no integer at all has nothing to offer either. Both must stay
+    /// `None` rather than wrap into a plausible-looking colour.
+    #[test]
+    fn as_i32_bits_refuses_what_is_not_a_32_bit_pattern() {
+        assert_eq!(true_color_pair("4294967296").as_i32_bits(), None);
+        assert_eq!(true_color_pair("-2147483649").as_i32_bits(), None);
+        assert_eq!(true_color_pair("not a number").as_i32_bits(), None);
+        // A Double code parses into `CodePairValue::Double`, not `Int`.
+        assert_eq!(DxfCodePair::new(40, "1.5".to_string()).as_i32_bits(), None);
     }
 }

--- a/tests/true_color_unsigned_accmcolor.rs
+++ b/tests/true_color_unsigned_accmcolor.rs
@@ -1,0 +1,101 @@
+//! An `AcCmColor` true colour written in its unsigned spelling must survive a
+//! DXF read.
+//!
+//! Group codes 420 and 421 carry a packed word, not a quantity: AutoCAD sets a
+//! method byte in the high position, `0xC2` for a true colour. A plain orange
+//! is therefore written `16746496` (0xFF8800) by a producer that omits the
+//! method byte, `-1023440896` by one that writes the full word signed, and
+//! `3271526400` by one that writes it unsigned. Only the first two fit an
+//! `i32`, so the reader used to drop the third: the colour never reached the
+//! entity and it fell back to its ACI index, which for a true-coloured entity
+//! is usually 256 (`ByLayer`).
+
+use std::io::Cursor;
+
+use acadrust::entities::{EntityType, Line};
+use acadrust::tables::Layer;
+use acadrust::types::{Color, DxfVersion};
+use acadrust::{CadDocument, DxfReader, DxfWriter};
+
+const ORANGE: Color = Color::Rgb {
+    r: 255,
+    g: 136,
+    b: 0,
+};
+
+/// A DXF holding one orange line on one orange layer, with every code 420
+/// value respelled as `spelling`.
+fn dxf_with_true_color_spelled(spelling: &str) -> Vec<u8> {
+    let mut document = CadDocument::with_version(DxfVersion::AC1032);
+    document
+        .layers
+        .add(Layer::with_color("Tinted", ORANGE))
+        .expect("layer");
+
+    let mut line = Line::from_coords(0.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+    line.common.layer = "Tinted".to_string();
+    line.common.color = ORANGE;
+    document.add_entity(EntityType::Line(line)).expect("entity");
+
+    let written = DxfWriter::new(&document).write_to_vec().expect("DXF write");
+    let text = String::from_utf8(written).expect("DXF is ASCII");
+    let mut out = String::with_capacity(text.len());
+    let mut respell_next = false;
+
+    for line in text.split_inclusive('\n') {
+        if respell_next {
+            let terminator = if line.ends_with("\r\n") { "\r\n" } else { "\n" };
+            out.push_str(spelling);
+            out.push_str(terminator);
+            respell_next = false;
+            continue;
+        }
+
+        respell_next = line.trim() == "420";
+        out.push_str(line);
+    }
+
+    assert!(out.contains(spelling), "no code 420 was respelled");
+
+    out.into_bytes()
+}
+
+fn read_colors(bytes: Vec<u8>) -> (Color, Color) {
+    let document = DxfReader::from_reader(Cursor::new(bytes))
+        .expect("DXF reader")
+        .read()
+        .expect("DXF read");
+    let entity = document.entities().next().expect("one entity");
+    let entity_color = match entity {
+        EntityType::Line(line) => line.common.color,
+        other => panic!("expected a LINE, got {other:?}"),
+    };
+
+    (
+        document.layers.get("Tinted").expect("layer").color,
+        entity_color,
+    )
+}
+
+#[test]
+fn a_true_color_written_unsigned_reaches_the_layer_and_the_entity() {
+    // 0xC2FF8800: the full AcCmColor word, method byte included, written as an
+    // unsigned 32-bit value. This is the spelling that used to be dropped.
+    let (layer, entity) = read_colors(dxf_with_true_color_spelled("3271526400"));
+
+    assert_eq!(layer, ORANGE);
+    assert_eq!(entity, ORANGE);
+}
+
+#[test]
+fn the_signed_and_bare_spellings_of_the_same_color_still_read() {
+    // -1023440896 is the same word written signed, 16746496 the bare 24 bits.
+    // Both already fitted an `i32`, so they guard against the fix narrowing
+    // what the reader accepts.
+    for spelling in ["-1023440896", "16746496"] {
+        let (layer, entity) = read_colors(dxf_with_true_color_spelled(spelling));
+
+        assert_eq!(layer, ORANGE, "layer, spelled {spelling}");
+        assert_eq!(entity, ORANGE, "entity, spelled {spelling}");
+    }
+}


### PR DESCRIPTION
### The bug

Group codes 420/421 carry a packed word, not a quantity: AutoCAD sets a method byte in the high position, `0xC2` for a true colour. The same orange therefore reaches the reader spelled three ways, and one of them is dropped:

| Spelling | Value | Read back |
| --- | --- | --- |
| Bare 24 bits | `16746496` | `#ff8800` |
| `0xC2FF8800` signed | `-1023440896` | `#ff8800` |
| `0xC2FF8800` unsigned | `3271526400` | **lost** |

`3271526400` does not fit an `i32`, so `as_i32` returns `None` and the arm never runs. The entity keeps whatever code 62 carried, which is not "no colour" but a *wrong* colour: writing a document with an orange line on an orange layer and reading it back with 420 respelled unsigned gives `Index(30)` on the entity and `Index(7)` on the layer, the nearest-ACI approximations this crate's own writer emits next to a true colour.

### The fix

`as_i32` is left alone, because it is right for a code carrying a number: a flags word of three billion is a malformed file, not a negative count. `as_i32_bits` admits the unsigned spelling by reinterpreting it as its two's complement, and the arms whose value then becomes a colour switch to it: 420/421, the 422-427 border colours of `TABLESTYLE`, and the `AcCmColor` values MULTILEADER carries in its 90-series. One colour code is deliberately not among them, see below. That includes four sites that store the raw word rather than decode it (`MATERIAL`'s ambient/diffuse/specular `rgb`, `ARCALIGNEDTEXT`'s `text_color`), where the same loss made the value `None` and the writer then emitted `0`. `true_color_bits` is the counterpart for the three sites that read `value_string` directly. `from_true_color_value` and `color_from_i32` already mask the method byte off, so neither decoder changes.

### One colour site deliberately left alone

`MLEADERSTYLE` reads its 91/93 colour codes with `as_i32` too, but decodes them with `Color::from_index(v as i16)` where `MULTILEADER` uses `color_from_i32` on the same codes. Widening the accessor there without touching the decoder would make things worse, not better: today an unsigned `AcCmColor` is rejected and the style keeps its default, whereas afterwards it would be truncated to its low 16 bits and become a garbage index. The real fix is to align the decoder, which changes behaviour beyond this PR. Happy to follow up separately if you want it.

### Tests

Unit tests on both helpers: both spellings, both ends of each half of the 32-bit range, values wider than `u32::MAX`, non-numeric text, and a `CodePairValue` that is not `Int`. Then `tests/true_color_unsigned_accmcolor.rs` proves the wiring end to end by respelling a written document's code 420 and reading it back.

`roundtrip::dwg_roundtrip_deep_r2000` fails on `main` at `c54d5a3` without this commit (3 diffs against an expected ≤ 1: object count 17 vs 13, class count 260 vs 38, a lost `Shape` name) and is unrelated to it.