### PR TITLE
bit_reader: read_raw_double without a heap allocation (~3.6x faster DWG load on large files)

### DIFF
--- a/src/io/dwg/dwg_stream_readers/bit_reader.rs
+++ b/src/io/dwg/dwg_stream_readers/bit_reader.rs
@@ -441,9 +441,14 @@ impl DwgBitReader {
 
     /// Read a raw double (RD type) — 8 bytes, little-endian IEEE 754.
     pub fn read_raw_double(&mut self) -> f64 {
-        let bytes = self.read_bytes(8);
+        // Read directly into a stack array: this is the hottest primitive in
+        // pass-2 decoding (every coordinate goes through here), and the
+        // previous `read_bytes(8)` did a heap allocation per double. On a
+        // 9 MB drawing (~82k records, ~1.6M doubles) that was ~45% of load
+        // time and, with rayon workers contending on the allocator lock,
+        // dominated the profile. Behaviour is byte-for-byte identical.
         let mut arr = [0u8; 8];
-        arr.copy_from_slice(&bytes);
+        self.apply_shift_to_arr(&mut arr);
         f64::from_le_bytes(arr)
     }
 


### PR DESCRIPTION
## What

`DwgBitReader::read_raw_double()` went through `read_bytes(8)`, which allocates a `Vec<u8>` for every double read. This change reads into a stack `[u8; 8]` via `apply_shift_to_arr` instead. Five lines, behaviour identical.

## Why

`read_raw_double` is the hottest primitive in pass-2 decoding — every coordinate, and in particular every ACIS wire-cache point, goes through it. On a 9.4 MB real-world architectural plan (≈82k records, ≈1.6M doubles) `perf` showed roughly **45% of total load time** in this one allocation plus allocator-lock contention between the rayon decode workers.

## Measured (aarch64, 2 cores, min of 3)

| | `DwgReader::read()` on the 9.4 MB plan |
|---|---|
| 0.5.5 as published | 8.2 s |
| this patch | **2.25 s** |

Output is byte-for-byte identical: the full entity dump serialised to JSON `cmp`s equal, and a rasterised render of the drawing `cmp`s equal.

## Notes

The other `read_bytes(n)` call sites in `bit_reader.rs` are variable-length string reads and are not on the hot path; left untouched.

Happy to adjust style if you'd prefer this expressed differently — the important part is just not allocating per double.
