### PR TITLE
DWG writer: keep the source class table when raw objects are passed through (pre-AC1027)

### DIFF
--- a/src/io/dwg/dwg_stream_readers/bit_reader.rs
+++ b/src/io/dwg/dwg_stream_readers/bit_reader.rs
@@ -441,9 +441,14 @@ impl DwgBitReader {
 
     /// Read a raw double (RD type) — 8 bytes, little-endian IEEE 754.
     pub fn read_raw_double(&mut self) -> f64 {
-        let bytes = self.read_bytes(8);
+        // Read directly into a stack array: this is the hottest primitive in
+        // pass-2 decoding (every coordinate goes through here), and the
+        // previous `read_bytes(8)` did a heap allocation per double. On a
+        // 9 MB drawing (~82k records, ~1.6M doubles) that was ~45% of load
+        // time and, with rayon workers contending on the allocator lock,
+        // dominated the profile. Behaviour is byte-for-byte identical.
         let mut arr = [0u8; 8];
-        arr.copy_from_slice(&bytes);
+        self.apply_shift_to_arr(&mut arr);
         f64::from_le_bytes(arr)
     }
 

--- a/src/io/dwg/dwg_writer.rs
+++ b/src/io/dwg/dwg_writer.rs
@@ -85,7 +85,16 @@ impl DwgWriter {
             if owned.has_null_table_entries() {
                 owned.assign_table_entry_handles();
             }
-            if owned.version < DxfVersion::AC1027 {
+            // Pruning the class table to the legacy whitelist renumbers every
+            // surviving class (500 + index). Unknown objects/entities carried
+            // verbatim from a same-version source still embed their *original*
+            // class numbers, so after pruning they point at a missing class or
+            // — worse — at a different one. Only prune when nothing is being
+            // passed through raw, i.e. the source was not this exact version.
+            let raw_passthrough = owned.dwg_source_version == Some(owned.version);
+            if owned.version < DxfVersion::AC1027 && raw_passthrough {
+                prepare_legacy_document(&mut owned);
+            } else if owned.version < DxfVersion::AC1027 {
                 let required: Vec<_> = owned
                     .entities()
                     .filter_map(|entity| {


### PR DESCRIPTION
## Problem

For targets older than AC1027, `DwgWriter` prunes the class table to the legacy whitelist (`retain_legacy_dwg_classes`) and renumbers the survivors to `500 + index`. But `Unknown` objects/entities carried verbatim from a same-version source (`register_raw_object`) still embed their **original** class numbers. After pruning they reference a class that no longer exists — or, worse, a different class that now occupies that number.

Reproduced with three real-world R2010 (AC1024) drawings (AEC / dynamic-block heavy): a plain round trip (read → change one TEXT value → write) leaves the object count intact but the written file has only 17 classes while objects still reference class numbers up to ~750.

libredwg `dwgread -v2` on the round-tripped file:
```
302 x  ERROR: Invalid object type N, only 17 classes
179 x  ERROR: Invalid class in# N >= 17
303 x  Warning: Object handle not found ...
```
(original file: 0 / 0 / 4)

## Fix

Only prune/renumber when nothing is being passed through raw, i.e. when `dwg_source_version != version`. Same-version round trips keep the class table exactly as read, which is what the positional class numbers inside the raw records require. `prepare_legacy_document` still runs in both cases.

After the fix, a per-type-code histogram of the written file (object map → type code, incl. non-entity objects) is identical to the source on all three drawings, and libredwg reports the same 0 / 0 / 4 as the original.

Branch is based on #76 (independent, one-line context overlap only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)