### PR TITLE
DWG writer: build owner→extension-dictionary index once (O(n²) → O(n))

### DIFF
--- a/src/io/dwg/dwg_stream_writers/object_writer/common.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/common.rs
@@ -780,8 +780,7 @@ impl<'a> DwgObjectWriter<'a> {
         // Only use it if the xdictionary object actually exists in document.objects,
         // otherwise BricsCAD reports "Object was erased" for the dangling reference.
         let effective_xdic = if xdictionary_handle.is_none() {
-            self.document
-                .extension_dictionary_handle(handle)
+            self.extension_dictionary_handle(handle)
                 .filter(|xdic| self.document.objects.contains_key(xdic))
         } else {
             *xdictionary_handle

--- a/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
+++ b/src/io/dwg/dwg_stream_writers/object_writer/mod.rs
@@ -128,6 +128,11 @@ pub struct DwgObjectWriter<'a> {
     /// Populated before writing any table controls so controls and records agree.
     #[allow(dead_code)]
     pub(super) linetype_handles: std::collections::HashMap<String, Handle>,
+    /// owner handle → extension dictionary handle, built once from `document.objects`.
+    /// `CadDocument::extension_dictionary_handle` falls back to a linear scan of every
+    /// object when the owner carries no xdictionary handle; called once per written
+    /// object that is O(objects²) — ~0.35 s of a 1.9 s write on a 5 500-object drawing.
+    pub(super) xdic_owner_index: std::sync::Arc<std::collections::HashMap<Handle, Handle>>,
 }
 
 struct ParallelEntityBatch {
@@ -258,7 +263,53 @@ impl<'a> DwgObjectWriter<'a> {
             class_counts_complete: true,
             owner_overrides: std::collections::HashMap::new(),
             linetype_handles: std::collections::HashMap::new(),
+            xdic_owner_index: std::sync::Arc::new(Self::build_xdic_owner_index(document)),
         })
+    }
+
+    /// owner → child dictionary (see `xdic_owner_index`). Mirrors the fallback in
+    /// `CadDocument::extension_dictionary_handle`: only dictionaries with a non-null
+    /// handle count, and a dictionary owned by another dictionary is *not* treated as
+    /// that dictionary's extension dictionary (ordinary child dictionaries live there).
+    fn build_xdic_owner_index(document: &CadDocument) -> std::collections::HashMap<Handle, Handle> {
+        let mut index = std::collections::HashMap::new();
+        for (handle, object) in &document.objects {
+            if let crate::objects::ObjectType::Dictionary(dictionary) = object {
+                if handle.is_null() || dictionary.owner.is_null() { continue }
+                if matches!(document.objects.get(&dictionary.owner), Some(crate::objects::ObjectType::Dictionary(_))) { continue }
+                index.entry(dictionary.owner).or_insert(*handle);
+            }
+        }
+        index
+    }
+
+    /// Same answer as `document.extension_dictionary_handle(owner)`, without the
+    /// per-call linear scan of every object.
+    pub(super) fn extension_dictionary_handle(&self, owner: Handle) -> Option<Handle> {
+        use crate::objects::ObjectType;
+        let document = self.document;
+        if let Some(entity) = document.get_entity(owner) {
+            if let Some(handle) = entity.common().xdictionary_handle {
+                return (!handle.is_null()).then_some(handle);
+            }
+        }
+        if let Some(handle) = document.xdic_by_handle.get(&owner).copied() {
+            return (!handle.is_null()).then_some(handle);
+        }
+        if let Some(handle) = match document.objects.get(&owner) {
+            Some(ObjectType::Dictionary(value)) => value.xdictionary_handle,
+            Some(ObjectType::Layout(value)) => value.xdictionary_handle,
+            Some(ObjectType::XRecord(value)) => value.xdictionary_handle,
+            Some(ObjectType::PlotSettings(value)) => value.xdictionary_handle,
+            Some(ObjectType::VisualStyle(value)) => value.xdictionary_handle,
+            Some(ObjectType::Material(value)) => value.xdictionary_handle,
+            Some(ObjectType::ProxyObject(value)) => value.xdictionary_handle,
+            _ => None,
+        } {
+            if !handle.is_null() { return Some(handle); }
+        }
+        if matches!(document.objects.get(&owner), Some(ObjectType::Dictionary(_))) { return None; }
+        self.xdic_owner_index.get(&owner).copied()
     }
 
     // ── Main entry point ────────────────────────────────────────────
@@ -1893,6 +1944,7 @@ impl<'a> DwgObjectWriter<'a> {
             pending_type_code: None,
             class_counts_complete: true,
             registered_handles: HashSet::with_capacity(handles.len()),
+            xdic_owner_index: self.xdic_owner_index.clone(),
             owner_overrides: std::collections::HashMap::new(),
             linetype_handles: std::collections::HashMap::new(),
         };


### PR DESCRIPTION
`CadDocument::extension_dictionary_handle` ends with a linear scan of `objects` when the owner has no `xdictionary_handle`. `DwgObjectWriter::write_common_non_entity_data_eed_internal` calls it once per written object, so writing is O(objects²) in the number of non-entity objects.

Measured on a real 9.4 MB R2010 drawing (84 k objects, 5 479 non-entity): `extension_dictionary_handle` is ~15 % of writer samples in `perf`; write time 1185 ms → 1029 ms (min of 5) with this change. Output is byte-identical (`cmp`).

Fix: build an `owner → dictionary` map once in `DwgObjectWriter::new` (same rules as the fallback: non-null handle, and a dictionary owned by another dictionary is not treated as its extension dictionary), share it with parallel batch writers, and resolve through it.

Branch is based on #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)