### PR TITLE
Add DwgReader::read_visiting for streaming DWG ingest

### DIFF
--- a/src/io/dwg/dwg_document_builder.rs
+++ b/src/io/dwg/dwg_document_builder.rs
@@ -417,6 +417,31 @@ pub struct DwgDocumentBuilder {
     progress: Option<std::sync::Arc<dyn Fn(u16) + Send + Sync>>,
 }
 
+fn accept_loaded_entity(
+    document: &mut CadDocument,
+    visit: &mut dyn FnMut(&CadDocument, EntityType) -> Option<EntityType>,
+    entity: EntityType,
+) {
+    if let Some(entity) = visit(document, entity) {
+        document.add_loaded_entity(entity);
+    }
+}
+
+fn accept_loaded_entity_batch(
+    document: &mut CadDocument,
+    visit: &mut dyn FnMut(&CadDocument, EntityType) -> Option<EntityType>,
+    entities: &mut Vec<std::sync::Arc<EntityType>>,
+) {
+    let mut kept = Vec::with_capacity(entities.len());
+    for entity in entities.drain(..) {
+        let owned = std::sync::Arc::try_unwrap(entity).unwrap_or_else(|arc| (*arc).clone());
+        if let Some(entity) = visit(document, owned) {
+            kept.push(std::sync::Arc::new(entity));
+        }
+    }
+    document.add_loaded_entity_batch(&mut kept);
+}
+
 impl DwgDocumentBuilder {
     /// Create a new builder wrapping the object reader.
     pub fn new(obj_reader: DwgObjectReader) -> Self {
@@ -458,7 +483,38 @@ impl DwgDocumentBuilder {
         self.build_with_stats(document).notifications
     }
 
-    pub fn build_with_stats(mut self, document: &mut CadDocument) -> DwgBuildOutcome {
+    /// Like [`build`], but each decoded entity is offered to `visit` before
+    /// it is stored. Return `None` to drop it from the document (the visitor
+    /// may consume it). Default [`build`] keeps every entity.
+    pub fn build_with_visitor<F>(
+        self,
+        document: &mut CadDocument,
+        visit: &mut F,
+    ) -> NotificationCollection
+    where
+        F: FnMut(&CadDocument, EntityType) -> Option<EntityType>,
+    {
+        self.build_with_optional_visitor(document, Some(visit))
+            .notifications
+    }
+
+    pub fn build_with_stats(self, document: &mut CadDocument) -> DwgBuildOutcome {
+        self.build_with_optional_visitor(document, None)
+    }
+
+    pub fn build_with_visitor_stats(
+        self,
+        document: &mut CadDocument,
+        visit: &mut dyn FnMut(&CadDocument, EntityType) -> Option<EntityType>,
+    ) -> DwgBuildOutcome {
+        self.build_with_optional_visitor(document, Some(visit))
+    }
+
+    fn build_with_optional_visitor(
+        mut self,
+        document: &mut CadDocument,
+        mut visit: Option<&mut dyn FnMut(&CadDocument, EntityType) -> Option<EntityType>>,
+    ) -> DwgBuildOutcome {
         let perf = std::env::var_os("PERF").is_some();
         let build_started = web_time::Instant::now();
         document
@@ -1643,7 +1699,11 @@ impl DwgDocumentBuilder {
                     document.section_view_style = chunk.output.section_view_style.take();
                 }
                 document.objects.extend(chunk.output.objects.drain());
-                document.add_loaded_entity_batch(&mut chunk.output.entities);
+                if let Some(visit) = visit.as_deref_mut() {
+                    accept_loaded_entity_batch(document, visit, &mut chunk.output.entities);
+                } else {
+                    document.add_loaded_entity_batch(&mut chunk.output.entities);
+                }
                 for (owner, mut vertices) in chunk.pending.vertices.drain() {
                     pending
                         .vertices
@@ -1790,7 +1850,11 @@ impl DwgDocumentBuilder {
                 }
             }
             decoded_pass2 = decoded_pass2.saturating_add(1);
-            document.add_loaded_entity(entity);
+            if let Some(visit) = visit.as_deref_mut() {
+                accept_loaded_entity(document, visit, entity);
+            } else {
+                document.add_loaded_entity(entity);
+            }
         }
 
         // ── Post-pass: Attach pending attribute entities to parent INSERTs ──

--- a/src/io/dwg/dwg_reader.rs
+++ b/src/io/dwg/dwg_reader.rs
@@ -858,9 +858,40 @@ impl<R: Read + Seek> DwgReader<R> {
         self.read_with_stats().map(|outcome| outcome.document)
     }
 
+    /// Like [`read`], but each pass-2 entity is offered to `visit` before it
+    /// is stored on the document. Return `None` to keep it out of
+    /// `CadDocument::entities` (the visitor may consume the value).
+    pub fn read_visiting<F>(
+        &mut self,
+        mut visit: F,
+    ) -> std::result::Result<crate::document::CadDocument, DxfError>
+    where
+        F: FnMut(
+            &crate::document::CadDocument,
+            crate::entities::EntityType,
+        ) -> Option<crate::entities::EntityType>,
+    {
+        self.read_with_optional_visitor(Some(&mut visit))
+            .map(|outcome| outcome.document)
+    }
+
     /// Read the file and return the document with source/decode statistics.
     pub fn read_with_stats(
         &mut self,
+    ) -> std::result::Result<crate::io::read::ReadOutcome, DxfError> {
+        self.read_with_optional_visitor(
+            None::<&mut dyn FnMut(&crate::document::CadDocument, crate::entities::EntityType) -> Option<crate::entities::EntityType>>,
+        )
+    }
+
+    fn read_with_optional_visitor(
+        &mut self,
+        visit: Option<
+            &mut dyn FnMut(
+                &crate::document::CadDocument,
+                crate::entities::EntityType,
+            ) -> Option<crate::entities::EntityType>,
+        >,
     ) -> std::result::Result<crate::io::read::ReadOutcome, DxfError> {
         let failsafe = self.options.failsafe;
         let perf = std::env::var_os("PERF").is_some();
@@ -1068,7 +1099,10 @@ impl<R: Read + Seek> DwgReader<R> {
                         if let Some(progress) = &self.progress {
                             builder.set_progress_callback(progress.clone());
                         }
-                        let build_outcome = builder.build_with_stats(&mut document);
+                        let build_outcome = match visit {
+                            Some(visit) => builder.build_with_visitor_stats(&mut document, visit),
+                            None => builder.build_with_stats(&mut document),
+                        };
                         decoded_source_records = build_outcome.decoded_records;
                         skipped_source_records = build_outcome.skipped_records;
                         diagnostics.extend(build_outcome.diagnostics);

--- a/tests/read_visiting.rs
+++ b/tests/read_visiting.rs
@@ -1,0 +1,59 @@
+//! Visitor hook: drop decoded entities before they are stored on the document.
+
+use std::io::Cursor;
+
+use acadrust::entities::{EntityType, Line};
+use acadrust::{CadDocument, DwgReader, DwgWriter};
+
+#[test]
+fn read_visiting_drops_model_lines_from_the_document() {
+    let mut doc = CadDocument::default();
+    for i in 0..64 {
+        let mut line = Line::from_coords(i as f64, 0.0, 0.0, i as f64 + 1.0, 0.0, 0.0);
+        line.common.layer = "SET".to_string();
+        doc.add_entity(EntityType::Line(line)).expect("line");
+    }
+
+    let bytes = DwgWriter::write_to_vec(&doc).expect("write dwg");
+    let mut dropped = 0u32;
+    let rebuilt = DwgReader::from_stream(Cursor::new(bytes))
+        .read_visiting(|_, entity| {
+            if matches!(entity, EntityType::Line(_)) {
+                dropped += 1;
+                None
+            } else {
+                Some(entity)
+            }
+        })
+        .expect("read_visiting");
+
+    assert!(
+        dropped >= 64,
+        "visitor should see the written lines, dropped={dropped}"
+    );
+    assert_eq!(
+        rebuilt
+            .entities()
+            .filter(|entity| matches!(entity, EntityType::Line(_)))
+            .count(),
+        0,
+        "dropped lines must not remain on the document"
+    );
+}
+
+#[test]
+fn read_keeps_every_entity() {
+    let mut doc = CadDocument::default();
+    doc.add_entity(EntityType::Line(Line::from_coords(0.0, 0.0, 0.0, 1.0, 0.0, 0.0)))
+        .expect("line");
+    let bytes = DwgWriter::write_to_vec(&doc).expect("write dwg");
+    let rebuilt = DwgReader::from_stream(Cursor::new(bytes))
+        .read()
+        .expect("read");
+    assert!(
+        rebuilt
+            .entities()
+            .any(|entity| matches!(entity, EntityType::Line(_))),
+        "default read() must keep entities"
+    );
+}


### PR DESCRIPTION
## Why

Large DWG files (survey / plant drawings) can decode more entities than a caller wants to keep in `CadDocument`. SpaceProof needs to stream or drop pass-2 entities during read so ingest can stay within a memory budget.

## What

- `DwgReader::read_visiting` offers each decoded entity to a callback before it is stored.
- Return `None` to drop or consume the entity; `Some(entity)` keeps it.
- Default `read()` / `build()` stay keep-all and still use the existing stats path (no extra Arc unwrap on the hot path).
- Parallel pass-2 decode is unchanged; the visitor runs on the sequential commit so `FnMut` stays valid.

A 0.4.1-based copy of the same hook lives on `SpaceProof/acadrust` branch `prove-0.4.1-visitor` for crates that cannot take unpublished 0.5.5 yet.

## Tests

`cargo test --test read_visiting`